### PR TITLE
Persist nested resources

### DIFF
--- a/game/resources.py
+++ b/game/resources.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, TYPE_CHECKING
 
 from .world import World
-from .game import Position, Faction
+
+if TYPE_CHECKING:
+    from .game import Position, Faction
 
 
 @dataclass

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import json
+import tempfile
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from game.game import Game
+from game.world import World
+import game.persistence as persistence
+
+
+def make_world():
+    w = World(width=3, height=3)
+    center = (1, 1)
+    for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
+        tile = w.get(center[0] + dq, center[1] + dr)
+        if tile:
+            tile["terrain"] = "plains"
+    return w
+
+
+def test_save_and_load(tmp_path, monkeypatch):
+    tmp_file = tmp_path / "save.json"
+    monkeypatch.setattr(persistence, "SAVE_FILE", tmp_file)
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+    player = game.player_faction.name
+    game.resources.data[player]["food"] = 7
+    game.save()
+
+    loaded = persistence.load_state()
+    assert loaded.resources[player]["food"] == 7
+


### PR DESCRIPTION
## Summary
- allow nested resources in persistence
- hook Game to use `ResourceManager` for saving/loading and ticking
- handle `ResourceManager` imports lazily to avoid circular references
- test saving and loading of resource data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409580e058832bb482291382d6636f