### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+*.egg
+*.egg-info/
+*.pyo
+*.pyd
+*.pyc
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Jupyter Notebook artifacts
+.ipynb_checkpoints
+
+# VS Code, PyCharm, and other IDEs
+.vscode/
+.idea/
+
+# Mac OS artifacts
+.DS_Store
+
+# Unit test / coverage
+.coverage
+.tox/
+


### PR DESCRIPTION
## Summary
- add a root `.gitignore` to ignore Python build artifacts and IDE files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'game.world')*

------
https://chatgpt.com/codex/tasks/task_e_68409f28ac08832bb1b39e6761735e49