### PR TITLE
Fix resource tick duplication and adjust tests

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -227,16 +227,17 @@ class Game:
             for building in faction.buildings:
                 b_type = getattr(building, "name", None)
                 if b_type == "Farm":
-                    faction.resources["food"] = faction.resources.get("food", 0) + 5
+                    bonus = getattr(building, "resource_bonus", 5)
+                    faction.resources["food"] = faction.resources.get("food", 0) + bonus
                 elif b_type == "LumberMill":
-                    faction.resources["wood"] = faction.resources.get("wood", 0) + 3
+                    bonus = getattr(building, "resource_bonus", 3)
+                    faction.resources["wood"] = faction.resources.get("wood", 0) + bonus
                 elif b_type == "Quarry":
-                    faction.resources["stone"] = faction.resources.get("stone", 0) + 2
+                    bonus = getattr(building, "resource_bonus", 2)
+                    faction.resources["stone"] = faction.resources.get("stone", 0) + bonus
                 elif b_type == "Mine":
-                    faction.resources["stone"] = faction.resources.get("stone", 0) + 4
-
-        # After all factions have been processed, update ResourceManager data
-        self.resources.tick(self.map.factions)
+                    bonus = getattr(building, "resource_bonus", 4)
+                    faction.resources["stone"] = faction.resources.get("stone", 0) + bonus
 
         # Debug output for the player faction
         if self.player_faction:

--- a/game/resources.py
+++ b/game/resources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, TYPE_CHECKING
 
-from .world import World, Hex
+from world.world import World, Hex
 
 if TYPE_CHECKING:
     from .game import Position, Faction

--- a/game/world.py
+++ b/game/world.py
@@ -1,0 +1,1 @@
+from world.world import *

--- a/tests/test_buildings.py
+++ b/tests/test_buildings.py
@@ -14,7 +14,7 @@ def make_world():
     for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
         tile = w.get(center[0] + dq, center[1] + dr)
         if tile:
-            tile["terrain"] = "plains"
+            tile.terrain = "plains"
     return w
 
 
@@ -35,7 +35,7 @@ def test_tick_applies_building_bonus():
     farm = Farm()
     farm.upgrade()
     faction.buildings.append(farm)
-    initial_population = faction.population
+    initial_population = faction.citizens.count
     game.tick()
     expected_food = (initial_population + 1) // 2 + farm.resource_bonus
     assert faction.resources["food"] == expected_food

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -16,7 +16,7 @@ def make_world():
     for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
         tile = w.get(center[0] + dq, center[1] + dr)
         if tile:
-            tile["terrain"] = "plains"
+            tile.terrain = "plains"
     return w
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -61,3 +61,14 @@ def test_quarry_increases_stone():
     game.tick()
     after = game.player_faction.resources["stone"]
     assert after - initial >= 2
+
+
+def test_resource_manager_updates_once():
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+    player = game.player_faction.name
+    before = game.resources.data[player]["food"]
+    game.tick()
+    after = game.resources.data[player]["food"]
+    assert after - before == 6


### PR DESCRIPTION
## Summary
- remove duplicate ResourceManager tick call
- factor building bonuses from upgrade levels
- expose world module as `game.world`
- update unit tests to match new behaviour
- add regression test ensuring ResourceManager tick runs once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409f2544a0832b994f4b89af1a1d38