### PR TITLE
Add simple rivers and lakes

### DIFF
--- a/tests/test_rivers.py
+++ b/tests/test_rivers.py
@@ -1,0 +1,7 @@
+from world.world import WorldSettings, World
+
+def test_rivers_generated():
+    settings = WorldSettings(seed=1, width=5, height=5, rainfall_intensity=1.0)
+    world = World(width=settings.width, height=settings.height, settings=settings)
+    assert len(world.rivers) > 0
+    assert any(hex_.lake for row in world.hexes for hex_ in row)

--- a/ui/map_view.py
+++ b/ui/map_view.py
@@ -152,14 +152,23 @@ class MapView:
             x2, y2 = self.camera.apply((x2, y2))
             dpg.draw_line((x1, y1), (x2, y2), color=(139, 69, 19, 255), thickness=4, parent=self.canvas)
 
+    def draw_rivers(self):
+        for seg in getattr(self.world, "rivers", []):
+            x1, y1 = hex_to_pixel(*seg.start)
+            x2, y2 = hex_to_pixel(*seg.end)
+            x1, y1 = self.camera.apply((x1, y1))
+            x2, y2 = self.camera.apply((x2, y2))
+            dpg.draw_line((x1, y1), (x2, y2), color=(65, 105, 225, 255), thickness=3, parent=self.canvas)
+
     def draw_map(self):
         dpg.delete_item(self.canvas, children_only=True)
         for r in range(self.world.height):
             for q in range(self.world.width):
                 hex_data = self.world.hexes[r][q]
-                color = terrain_color(hex_data.terrain)
+                color = terrain_color("water" if hex_data.lake else hex_data.terrain)
                 self.draw_hex(q, r, color, 0)
         self.draw_roads()
+        self.draw_rivers()
         if self.selected:
             q, r = self.selected
             self.draw_hex(q, r, (255, 255, 0, 255), 3)

--- a/world/__init__.py
+++ b/world/__init__.py
@@ -3,6 +3,7 @@ from .world import (
     WorldSettings,
     Hex,
     Road,
+    RiverSegment,
     World,
     adjust_settings,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "WorldSettings",
     "Hex",
     "Road",
+    "RiverSegment",
     "World",
     "adjust_settings",
 ]


### PR DESCRIPTION
## Summary
- add `RiverSegment` dataclass and rainfall slider
- generate rivers/lakes based on heightmap
- expose new water features via `World` and `MapView`
- add regression test for river generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840aa73e234832ba4dbda9285ec0d0d