### PR TITLE
Gather resources from hex data

### DIFF
--- a/game/resources.py
+++ b/game/resources.py
@@ -43,26 +43,11 @@ class ResourceManager:
         resources = self.data[faction.name]
         tiles = self.adjacent_tiles(faction.settlement.position)
 
-        terrain_map: Dict[str, ResourceType] = {
-            "plains": ResourceType.FOOD,
-            "hills": ResourceType.FOOD,
-            "forest": ResourceType.WOOD,
-            "mountains": ResourceType.STONE,
-            "rainforest": ResourceType.WOOD,
-            "desert": ResourceType.STONE,
-            "tundra": ResourceType.FOOD,
-        }
-
-        # Count how many tiles of each resource type are adjacent
-        counts: Dict[ResourceType, int] = {
-            ResourceType.FOOD: 0,
-            ResourceType.WOOD: 0,
-            ResourceType.STONE: 0,
-        }
+        # Count how many tiles yield each resource type
+        counts: Dict[ResourceType, int] = {}
         for tile in tiles:
-            res = terrain_map.get(tile.terrain)
-            if res is not None:
-                counts[res] += 1
+            for res_type in tile.resources.keys():
+                counts[res_type] = counts.get(res_type, 0) + 1
 
         # Determine how many workers can gather (limited by assigned workers and available citizens)
         workers_available = min(faction.workers.assigned, faction.citizens.count)
@@ -70,6 +55,8 @@ class ResourceManager:
         # Gather from each resource type up to the number of available workers
         for res_type, tile_count in counts.items():
             gathered = min(tile_count, workers_available)
+            if res_type not in resources:
+                resources[res_type] = 0
             resources[res_type] += gathered
 
     def tick(self, factions: List["Faction"]) -> None:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -39,6 +39,12 @@ def test_offline_gains(tmp_path, monkeypatch):
     monkeypatch.setattr(persistence, "SAVE_FILE", tmp_file)
 
     world = make_world()
+    center = (1, 1)
+    for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
+        tile = world.get(center[0] + dq, center[1] + dr)
+        if tile:
+            tile.resources = {ResourceType.ORE: 1}
+
     game = Game(world=world)
     game.place_initial_settlement(1, 1)
     player = game.player_faction.name
@@ -50,4 +56,4 @@ def test_offline_gains(tmp_path, monkeypatch):
     loaded = persistence.load_state(world=world, factions=[game.player_faction])
 
     assert loaded.population == 5
-    assert loaded.resources[player][ResourceType.FOOD] == 30
+    assert loaded.resources[player][ResourceType.ORE] == 30

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -65,10 +65,16 @@ def test_quarry_increases_stone():
 
 def test_resource_manager_updates_once():
     world = make_world()
+    center = (1, 1)
+    for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
+        tile = world.get(center[0] + dq, center[1] + dr)
+        if tile:
+            tile.resources = {ResourceType.ORE: 1}
+
     game = Game(world=world)
     game.place_initial_settlement(1, 1)
     player = game.player_faction.name
-    before = game.resources.data[player][ResourceType.FOOD]
+    before = game.resources.data[player][ResourceType.ORE]
     game.tick()
-    after = game.resources.data[player][ResourceType.FOOD]
+    after = game.resources.data[player][ResourceType.ORE]
     assert after - before == 6


### PR DESCRIPTION
## Summary
- collect resources adjacent to each settlement by reading hex resource dictionaries
- update persistence test for offline gains
- update resources test to verify ore gathering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b3ce1244832b84a5d79c7b22550d