### PR TITLE
Fix population persistence

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -268,10 +268,12 @@ class Game:
                 if building.resource_type is not None:
                     current = faction.resources.get(building.resource_type, 0)
                     faction.resources[building.resource_type] = (
-                        current + building.resource_bonus
-                    )
+                    current + building.resource_bonus
+                )
 
-        # After all factions have been processed, update ResourceManager data
+        # After all factions have been processed, update overall population and
+        # ResourceManager data
+        self.population = sum(f.citizens.count for f in self.map.factions)
         self.resources.tick(self.map.factions)
 
         # Debug output for the player faction
@@ -281,6 +283,7 @@ class Game:
             print(f"Resources: {res} | Population: {pop}")
 
     def save(self) -> None:
+        self.population = sum(f.citizens.count for f in self.map.factions)
         self.state.resources = self.resources.data
         self.state.population = self.population
         save_state(self.state)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -49,5 +49,23 @@ def test_offline_gains(tmp_path, monkeypatch):
     monkeypatch.setattr(persistence.time, "time", lambda: 1005.0)
     loaded = persistence.load_state(world=world, factions=[game.player_faction])
 
-    assert loaded.population == 5
+    assert loaded.population == 15
     assert loaded.resources[player][ResourceType.FOOD] == 30
+
+
+def test_save_updates_population(tmp_path, monkeypatch):
+    tmp_file = tmp_path / "save.json"
+    monkeypatch.setattr(persistence, "SAVE_FILE", tmp_file)
+
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+
+    # Run one tick to trigger population growth and recalculation
+    game.tick()
+    game.save()
+
+    with open(tmp_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["population"] == 11


### PR DESCRIPTION
## Summary
- recalculate total population in each game tick
- recompute population before saving
- update tests for new population handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b3ce4ce4832ba1699ecbebeb72c9