### PR TITLE
Fix mountains terrain naming

### DIFF
--- a/world/generation.py
+++ b/world/generation.py
@@ -143,7 +143,7 @@ def terrain_from_elevation(
         return "plains"
     if value < settings.sea_level + 0.4:
         return "hills"
-    return "mountain"
+    return "mountains"
 
 
 # -- Climate and biome utilities ------------------------------------------------


### PR DESCRIPTION
## Summary
- standardize on `"mountains"` terrain label across world generation

## Testing
- `pytest tests/test_resources.py::test_resources_increase_without_buildings -q`
- `pytest -q` *(fails: test_offline_gains)*

------
https://chatgpt.com/codex/tasks/task_e_6840c3364ecc832b86b7b40203708df4