### PR TITLE
Add biome-based world generation

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -226,6 +226,7 @@ class Game:
         self.map.add_faction(self.player_faction)
         # Register resources for the new faction
         self.resources.register(self.player_faction)
+        self.population = self.player_faction.citizens.count
 
     def add_building(self, building: Building):
         """Add a defensive building to the player's settlement."""

--- a/tests/test_biomes.py
+++ b/tests/test_biomes.py
@@ -1,0 +1,19 @@
+from world.world import WorldSettings, World
+from world.generation import generate_biome_map
+
+
+def test_temperature_and_rainfall_maps():
+    settings = WorldSettings(seed=1, width=3, height=3)
+    world = World(width=settings.width, height=settings.height, settings=settings)
+    assert len(world.temperature_map) == settings.height
+    assert len(world.temperature_map[0]) == settings.width
+    assert len(world.rainfall_map) == settings.height
+    assert len(world.rainfall_map[0]) == settings.width
+
+
+def test_biome_map_used_for_terrain():
+    settings = WorldSettings(seed=2, width=4, height=4)
+    world = World(width=settings.width, height=settings.height, settings=settings)
+    expected = generate_biome_map(world.elevation_map, world.temperature_map, world.rainfall_map)
+    terrains = [[h.terrain for h in row] for row in world.hexes]
+    assert terrains == expected


### PR DESCRIPTION
## Summary
- generate temperature and rainfall maps alongside elevation
- classify biomes using climate data and store the resulting maps
- expand resource rules for tundra and rainforest
- record population on settlement placement
- test biome map generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c338869c832ba1becdeb1c0764d1