### PR TITLE
Add on-demand chunk generation

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -226,6 +226,8 @@ class Game:
         self.map.add_faction(self.player_faction)
         # Register resources for the new faction
         self.resources.register(self.player_faction)
+        # Track initial population for save games
+        self.population = self.player_faction.citizens.count
 
     def add_building(self, building: Building):
         """Add a defensive building to the player's settlement."""

--- a/ui/map_view.py
+++ b/ui/map_view.py
@@ -162,11 +162,16 @@ class MapView:
 
     def draw_map(self):
         dpg.delete_item(self.canvas, children_only=True)
-        for r in range(self.world.height):
-            for q in range(self.world.width):
-                hex_data = self.world.hexes[r][q]
-                color = terrain_color("water" if hex_data.lake else hex_data.terrain)
-                self.draw_hex(q, r, color, 0)
+        tl = self.camera.reverse((0, 0))
+        br = self.camera.reverse(self.size)
+        qmin, rmin = pixel_to_hex(*tl)
+        qmax, rmax = pixel_to_hex(*br)
+        for r in range(rmin - 2, rmax + 3):
+            for q in range(qmin - 2, qmax + 3):
+                hex_data = self.world.get(q, r)
+                if hex_data:
+                    color = terrain_color("water" if hex_data.lake else hex_data.terrain)
+                    self.draw_hex(q, r, color, 0)
         self.draw_roads()
         self.draw_rivers()
         if self.selected:

--- a/world/world.py
+++ b/world/world.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Tuple, Optional
 
-from .generation import generate_elevation_map, terrain_from_elevation
+from .generation import perlin_noise, terrain_from_elevation
 
 Coordinate = Tuple[int, int]
 
@@ -152,12 +152,13 @@ class World:
         settings: Optional[WorldSettings] = None,
     ) -> None:
         self.settings = settings or WorldSettings(seed=seed, width=width, height=height)
+        self.chunks: Dict[Tuple[int, int], List[List[Hex]]] = {}
         self.hexes: List[List[Hex]] = []
         self.roads: List[Road] = []
         self.rivers: List[RiverSegment] = []
         self.lakes: List[Coordinate] = []
         self.rng = initialize_random(self.settings)
-        self._generate_hexes()
+        self._initialize_base_area()
         self._generate_rivers()
 
     @property
@@ -168,20 +169,22 @@ class World:
     def height(self) -> int:
         return self.settings.height
 
-    def _generate_hexes(self) -> None:
-        elevation_map = generate_elevation_map(self.settings.width, self.settings.height, self.settings)
+    CHUNK_SIZE = 10
+
+    def _initialize_base_area(self) -> None:
         for r in range(self.settings.height):
             row: List[Hex] = []
             for q in range(self.settings.width):
-                elevation = elevation_map[r][q]
-                row.append(self._generate_hex(q, r, elevation))
+                row.append(self.get(q, r))
             self.hexes.append(row)
 
-    def _generate_hex(self, q: int, r: int, elevation: float) -> Hex:
+    def _generate_hex(self, q: int, r: int) -> Hex:
+        rng = random.Random(hash((q, r, self.settings.seed)))
+        elevation = perlin_noise(q, r, self.settings.seed)
         terrain = terrain_from_elevation(elevation, self.settings)
-        moisture = self.rng.random() * self.settings.moisture
-        temperature = self.rng.random() * self.settings.temperature
-        resources = generate_resources(self.rng, terrain)
+        moisture = rng.random() * self.settings.moisture
+        temperature = rng.random() * self.settings.temperature
+        resources = generate_resources(rng, terrain)
         return Hex(
             coord=(q, r),
             terrain=terrain,
@@ -191,12 +194,25 @@ class World:
             resources=resources,
         )
 
+    def _generate_chunk(self, cx: int, cy: int) -> None:
+        chunk: List[List[Hex]] = []
+        base_q = cx * self.CHUNK_SIZE
+        base_r = cy * self.CHUNK_SIZE
+        for r_off in range(self.CHUNK_SIZE):
+            row: List[Hex] = []
+            for q_off in range(self.CHUNK_SIZE):
+                q = base_q + q_off
+                r = base_r + r_off
+                row.append(self._generate_hex(q, r))
+            chunk.append(row)
+        self.chunks[(cx, cy)] = chunk
+
     def _neighbors(self, q: int, r: int) -> List[Coordinate]:
         directions = [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]
         return [
             (q + dq, r + dr)
             for dq, dr in directions
-            if self.get(q + dq, r + dr) is not None
+            if 0 <= q + dq < self.settings.width and 0 <= r + dr < self.settings.height
         ]
 
     def _downhill_neighbor(self, q: int, r: int) -> Optional[Coordinate]:
@@ -232,7 +248,7 @@ class World:
             while current and current not in visited:
                 visited.add(current)
                 nxt = self._downhill_neighbor(*current)
-                if not nxt or nxt == current:
+                if not nxt or nxt == current or not (0 <= nxt[0] < self.width and 0 <= nxt[1] < self.height):
                     self.lakes.append(current)
                     self.get(*current).lake = True
                     break
@@ -241,9 +257,14 @@ class World:
                 current = nxt
 
     def get(self, q: int, r: int) -> Optional[Hex]:
-        if 0 <= q < self.settings.width and 0 <= r < self.settings.height:
-            return self.hexes[r][q]
-        return None
+        cx = q // self.CHUNK_SIZE
+        cy = r // self.CHUNK_SIZE
+        if (cx, cy) not in self.chunks:
+            self._generate_chunk(cx, cy)
+        chunk = self.chunks.get((cx, cy))
+        if chunk is None:
+            return None
+        return chunk[r % self.CHUNK_SIZE][q % self.CHUNK_SIZE]
 
     def resources_near(self, x: int, y: int, radius: int = 1) -> Dict[ResourceType, int]:
         totals: Dict[ResourceType, int] = {r: 0 for r in ResourceType}


### PR DESCRIPTION
## Summary
- store world data in 10x10 chunks and generate them lazily
- update `get`/river generation to work with chunks
- make `MapView` render only visible hexes
- track initial population during settlement placement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c3398af0832bbabfcd39f09e03f8