### PR TITLE
Use FactionManager in game ticks

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -17,7 +17,7 @@ from .buildings import (
     mitigate_building_damage,
     mitigate_population_loss,
 )
-from .population import Citizen, Worker
+from .population import Citizen, Worker, FactionManager
 from . import settings
 from world.world import World, ResourceType
 from .resources import ResourceManager
@@ -208,8 +208,9 @@ class Game:
             timestamp=time.time(), resources={}, population=0, claimed_projects=[]
         )
 
-        # Initialize resource manager with whatever data we have so far
+        # Initialize managers for resources and populations
         self.resources = ResourceManager(self.world, self.state.resources)
+        self.faction_manager = FactionManager()
 
         self.population = self.state.population
         self.claimed_projects: set[str] = set(self.state.claimed_projects)
@@ -224,8 +225,10 @@ class Game:
         settlement = Settlement(name="Home", position=pos)
         self.player_faction = Faction(name=name, settlement=settlement)
         self.map.add_faction(self.player_faction)
-        # Register resources for the new faction
+        # Register resources and population management for the new faction
         self.resources.register(self.player_faction)
+        self.faction_manager.add_faction(self.player_faction)
+        self.population = self.player_faction.citizens.count
 
     def add_building(self, building: Building):
         """Add a defensive building to the player's settlement."""
@@ -237,6 +240,7 @@ class Game:
         ai_factions = self.map.spawn_ai_factions(self.player_faction.settlement)
         for faction in self.map.factions:
             self.resources.register(faction)
+            self.faction_manager.add_faction(faction)
 
         # Peek saved state to rebuild world and faction data
         initial_state = load_state()
@@ -355,15 +359,15 @@ class Game:
     def tick(self) -> None:
         """
         Advance the game state by one tick. This includes:
-          1. Population growth
+          1. Population growth via ``FactionManager``
           2. Basic resource generation (food from population)
           3. Building-based resource bonuses
         """
-        for faction in self.map.factions:
-            # 1. Population growth
-            faction.citizens.count += 1
+        # Update population for all factions
+        self.faction_manager.tick()
 
-            # 2. Generate base food from population
+        for faction in self.map.factions:
+            # 1. Generate base food from population
             food_gain = faction.citizens.count // 2
             faction.resources[ResourceType.FOOD] = (
                 faction.resources.get(ResourceType.FOOD, 0) + food_gain

--- a/game/population.py
+++ b/game/population.py
@@ -41,7 +41,8 @@ class FactionManager:
             self.assign_strategy = self._default_assign_strategy
 
     def add_faction(self, faction: Faction) -> None:
-        self.factions.append(faction)
+        if faction not in self.factions:
+            self.factions.append(faction)
 
     def assign_workers(self, faction: Faction, number: int) -> int:
         """Assign available citizens as workers."""

--- a/tests/test_buildings.py
+++ b/tests/test_buildings.py
@@ -32,7 +32,7 @@ def test_building_upgrade():
     assert farm.upkeep == int(10 * 1.2)
 
 
-def test_tick_applies_building_bonus():
+def test_tick_applies_building_bonus(monkeypatch):
     world = make_world()
     game = Game(world=world)
     game.place_initial_settlement(1, 1)
@@ -45,9 +45,16 @@ def test_tick_applies_building_bonus():
     farm = Farm()
     farm.upgrade()
     faction.buildings.append(farm)
+
+    # Deterministic population change: +1 citizen
+    values = [1, 0, 0]
+    monkeypatch.setattr("random.randint", lambda a, b: values.pop(0))
+
     initial_population = faction.citizens.count
     game.tick()
+
     expected_food = (initial_population + 1) // 2 + farm.resource_bonus
+    assert faction.citizens.count == initial_population + 1
     assert faction.resources[ResourceType.FOOD] == expected_food
 
 

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -3,7 +3,8 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from game.population import FactionManager, Citizen, Worker
-from game.game import Faction, Settlement, Position
+from game.game import Faction, Settlement, Position, Game
+from world.world import World
 
 
 def make_faction(pop=10):
@@ -38,3 +39,27 @@ def test_tick_migration(monkeypatch):
     monkeypatch.setattr("random.randint", fake_randint)
     mgr.tick()
     assert faction.citizens.count == 9
+
+
+def make_world():
+    w = World(width=3, height=3)
+    center = (1, 1)
+    for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
+        tile = w.get(center[0] + dq, center[1] + dr)
+        if tile:
+            tile.terrain = "plains"
+    return w
+
+
+def test_game_tick_updates_population(monkeypatch):
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+
+    values = [2, 0, 0]
+    monkeypatch.setattr("random.randint", lambda a, b: values.pop(0))
+
+    initial = game.player_faction.citizens.count
+    game.tick()
+
+    assert game.player_faction.citizens.count == initial + 2

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -63,7 +63,7 @@ def test_quarry_increases_stone():
     assert after - initial >= 2
 
 
-def test_resource_manager_updates_once():
+def test_resource_manager_updates_once(monkeypatch):
     world = make_world()
     center = (1, 1)
     for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
@@ -74,13 +74,17 @@ def test_resource_manager_updates_once():
     game = Game(world=world)
     game.place_initial_settlement(1, 1)
     player = game.player_faction.name
+
+    values = [0, 0, 0]
+    monkeypatch.setattr("random.randint", lambda a, b: values.pop(0))
+
     before = game.resources.data[player][ResourceType.ORE]
     game.tick()
     after = game.resources.data[player][ResourceType.ORE]
     assert after - before == 6
 
 
-def test_auto_assignment_gathers_resources():
+def test_auto_assignment_gathers_resources(monkeypatch):
     """Idle citizens should automatically become workers and gather."""
     world = make_world()
     center = (1, 1)
@@ -94,13 +98,17 @@ def test_auto_assignment_gathers_resources():
     # Remove all assigned workers to simulate idle population
     game.player_faction.workers.assigned = 0
     player = game.player_faction.name
+
+    values = [0, 0, 0]
+    monkeypatch.setattr("random.randint", lambda a, b: values.pop(0))
+
     before = game.resources.data[player][ResourceType.WOOD]
     game.tick()
     after = game.resources.data[player][ResourceType.WOOD]
     assert after - before == 6
 
 
-def test_richer_tiles_yield_more_resources():
+def test_richer_tiles_yield_more_resources(monkeypatch):
     world = make_world()
     center = (1, 1)
     amounts = [5, 1, 1, 1, 1, 1]
@@ -114,6 +122,10 @@ def test_richer_tiles_yield_more_resources():
     game = Game(world=world)
     game.place_initial_settlement(1, 1)
     player = game.player_faction.name
+
+    values = [0, 0, 0]
+    monkeypatch.setattr("random.randint", lambda a, b: values.pop(0))
+
     before = game.resources.data[player][ResourceType.ORE]
     game.tick()
     after = game.resources.data[player][ResourceType.ORE]


### PR DESCRIPTION
## Summary
- manage factions with `FactionManager` in `Game`
- update populations each tick using the manager
- register factions with the manager when created
- avoid duplicate faction registration
- adjust tests to check population updates and make population-related tests deterministic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c470db70832bac43bc8f9f6ef097