### PR TITLE
Update tectonic slider usage

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -226,6 +226,8 @@ class Game:
         self.map.add_faction(self.player_faction)
         # Register resources for the new faction
         self.resources.register(self.player_faction)
+        # Ensure population reflects the newly founded settlement
+        self.population = self.player_faction.citizens.count
 
     def add_building(self, building: Building):
         """Add a defensive building to the player's settlement."""

--- a/ui/world_setup.py
+++ b/ui/world_setup.py
@@ -61,7 +61,7 @@ class WorldSetupUI:
                 tag="tectonic",
                 min_value=0.0,
                 max_value=1.0,
-                default_value=self.settings.tectonic_activity,
+                default_value=self.settings.plate_activity,
                 callback=self._update_world,
             )
             dpg.add_button(label="Confirm", callback=self._confirm)
@@ -73,7 +73,7 @@ class WorldSetupUI:
         self.settings.elevation = dpg.get_value("elevation")
         self.settings.temperature = dpg.get_value("temperature")
         self.settings.moisture = dpg.get_value("moisture")
-        self.settings.tectonic_activity = dpg.get_value("tectonic")
+        self.settings.plate_activity = dpg.get_value("tectonic")
 
         self.world = World(
             width=self.settings.width,


### PR DESCRIPTION
## Summary
- sync population after settlement placement
- use `plate_activity` in world setup UI

## Testing
- `pytest -q`
- `python -m ui.world_setup` *(fails: GLFW needs DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6840c4735b94832bb7993bee35199cb4