### PR TITLE
Delegate worker auto-assignment to FactionManager

### DIFF
--- a/game/resources.py
+++ b/game/resources.py
@@ -36,11 +36,10 @@ class ResourceManager:
         resources = self.data[faction.name]
         tiles = self.adjacent_tiles(faction.settlement.position)
 
-        # Automatically assign any idle citizens to gathering if the faction is
-        # not under manual worker control.
-        if not getattr(faction, "manual_assignment", False):
-            idle = faction.workers.available(faction.citizens.count)
-            faction.workers.assigned += idle
+
+        # Worker assignment is now handled entirely by ``FactionManager``.
+        # ``ResourceManager`` assumes the ``assigned`` count is already
+        # up to date when gathering occurs.
 
         # Sum resource values for adjacent tiles
         counts: Dict[ResourceType, int] = {}

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -98,6 +98,8 @@ def test_auto_assignment_gathers_resources(monkeypatch):
     game.place_initial_settlement(1, 1)
     # Remove all assigned workers to simulate idle population
     game.player_faction.workers.assigned = 0
+    # Ensure precondition holds
+    assert game.player_faction.workers.assigned == 0
     player = game.player_faction.name
 
     values = [0, 0, 0]
@@ -106,6 +108,8 @@ def test_auto_assignment_gathers_resources(monkeypatch):
     before = game.resources.data[player][ResourceType.WOOD]
     game.tick()
     after = game.resources.data[player][ResourceType.WOOD]
+    # FactionManager should have assigned all idle citizens as workers
+    assert game.player_faction.workers.assigned == game.player_faction.citizens.count
     assert after - before == 6
 
 


### PR DESCRIPTION
## Summary
- remove automatic worker assignment from `ResourceManager.gather_for_faction`
- ensure tests expect `FactionManager` to assign idle citizens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840dd3da86c832ba6a61d8707ec2649