### PR TITLE
Add advanced resource generation

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from game.game import Game
-from world.world import World, ResourceType
+from world.world import World, WorldSettings, ResourceType
 from game.resources import ResourceManager
 from game.buildings import Farm, LumberMill, Quarry, Mine
 
@@ -173,3 +173,19 @@ def test_register_uses_faction_resources():
     manager.register(faction)
 
     assert manager.data[faction.name][ResourceType.FOOD] == expected_food
+
+
+def test_advanced_resources_generated():
+    """World generation should include some rare resources."""
+    settings = WorldSettings(seed=42, width=5, height=5)
+    world = World(width=settings.width, height=settings.height, settings=settings)
+
+    advanced = {ResourceType.IRON, ResourceType.GOLD, ResourceType.WHEAT, ResourceType.WOOL}
+    found: set[ResourceType] = set()
+    for row in world.hexes:
+        for hex_ in row:
+            for res in hex_.resources:
+                if res in advanced:
+                    found.add(res)
+
+    assert any(res in found for res in advanced)

--- a/world/world.py
+++ b/world/world.py
@@ -126,32 +126,58 @@ def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, i
         resources[ResourceType.WOOD] = rng.randint(5, 15)
         if rng.random() < 0.3:
             resources[ResourceType.STONE] = rng.randint(1, 4)
+        if rng.random() < 0.1:
+            resources[ResourceType.WOOL] = rng.randint(1, 3)
     elif terrain == "mountains":
         resources[ResourceType.STONE] = rng.randint(5, 15)
         if rng.random() < 0.7:
             resources[ResourceType.ORE] = rng.randint(1, 5)
+        if rng.random() < 0.4:
+            resources[ResourceType.IRON] = rng.randint(1, 3)
+        if rng.random() < 0.2:
+            resources[ResourceType.GOLD] = rng.randint(1, 2)
     elif terrain == "hills":
         if rng.random() < 0.5:
             resources[ResourceType.WOOD] = rng.randint(1, 5)
         if rng.random() < 0.6:
             resources[ResourceType.STONE] = rng.randint(1, 4)
+        if rng.random() < 0.4:
+            resources[ResourceType.ORE] = rng.randint(1, 3)
+        if rng.random() < 0.2:
+            resources[ResourceType.IRON] = rng.randint(1, 2)
+        if rng.random() < 0.05:
+            resources[ResourceType.GOLD] = rng.randint(1, 1)
     elif terrain == "plains":
         if rng.random() < 0.5:
             resources[ResourceType.WOOD] = rng.randint(1, 5)
         if rng.random() < 0.4:
             resources[ResourceType.STONE] = rng.randint(1, 4)
+        if rng.random() < 0.3:
+            resources[ResourceType.WHEAT] = rng.randint(1, 4)
+        if rng.random() < 0.2:
+            resources[ResourceType.WOOL] = rng.randint(1, 2)
     elif terrain == "desert":
         if rng.random() < 0.2:
             resources[ResourceType.STONE] = rng.randint(1, 3)
+        if rng.random() < 0.1:
+            resources[ResourceType.ORE] = rng.randint(1, 2)
+        if rng.random() < 0.05:
+            resources[ResourceType.GOLD] = rng.randint(1, 1)
     elif terrain == "tundra":
         if rng.random() < 0.3:
             resources[ResourceType.STONE] = rng.randint(1, 4)
         if rng.random() < 0.2:
             resources[ResourceType.WOOD] = rng.randint(1, 3)
+        if rng.random() < 0.25:
+            resources[ResourceType.WOOL] = rng.randint(1, 3)
     elif terrain == "rainforest":
         resources[ResourceType.WOOD] = rng.randint(8, 20)
         if rng.random() < 0.3:
             resources[ResourceType.VEGETABLE] = rng.randint(1, 3)
+        if rng.random() < 0.15:
+            resources[ResourceType.WHEAT] = rng.randint(1, 2)
+        if rng.random() < 0.1:
+            resources[ResourceType.WOOL] = rng.randint(1, 2)
     elif terrain == "water":
         pass
 


### PR DESCRIPTION
## Summary
- extend `generate_resources` with advanced ores, crops, and wool spawns in suitable biomes
- add test confirming advanced resources appear for a fixed seed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840dd3eeccc832ba31544cf1184ca93