### PR TITLE
Add new resource types with categories

### DIFF
--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -97,7 +97,7 @@ def test_offline_processing_buildings(tmp_path, monkeypatch):
     ticks = int((1003.0 - 1000.0) // persistence.TICK_DURATION)
     values = [0, 0, 0] * ticks
     monkeypatch.setattr("random.randint", lambda a, b: values.pop(0))
-    loaded = persistence.load_state(world=world, factions=[faction])
+    loaded, _ = persistence.load_state(world=world, factions=[faction])
 
     assert loaded.resources[player][ResourceType.METAL] == 4
     assert loaded.resources[player][ResourceType.ORE] == 0
@@ -162,7 +162,7 @@ def test_offline_project_completion(tmp_path, monkeypatch):
     monkeypatch.setattr(persistence.time, "time", lambda: offline_time)
     monkeypatch.setattr("random.randint", lambda a, b: 0)
 
-    loaded = persistence.load_state(world=world, factions=[faction])
+    loaded, _ = persistence.load_state(world=world, factions=[faction])
 
     assert faction.projects[0].is_complete()
     player = faction.name

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,7 +5,13 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from game.game import Game
-from world.world import World, WorldSettings, ResourceType
+from world.world import (
+    World,
+    WorldSettings,
+    ResourceType,
+    STRATEGIC_RESOURCES,
+    LUXURY_RESOURCES,
+)
 from game.resources import ResourceManager
 from game.buildings import Farm, LumberMill, Quarry, Mine
 
@@ -193,3 +199,23 @@ def test_advanced_resources_generated():
                     found.add(res)
 
     assert any(res in found for res in advanced)
+
+
+def test_strategic_and_luxury_resources_generated():
+    """World generation should include strategic and luxury resources."""
+    settings = WorldSettings(seed=99, width=10, height=10)
+    world = World(width=settings.width, height=settings.height, settings=settings)
+
+    strategic_found: set[ResourceType] = set()
+    luxury_found: set[ResourceType] = set()
+
+    for row in world.hexes:
+        for hex_ in row:
+            for res in hex_.resources:
+                if res in STRATEGIC_RESOURCES:
+                    strategic_found.add(res)
+                if res in LUXURY_RESOURCES:
+                    luxury_found.add(res)
+
+    assert strategic_found
+    assert luxury_found

--- a/world/world.py
+++ b/world/world.py
@@ -40,6 +40,36 @@ class ResourceType(Enum):
     GOLD = "gold"
     IRON = "iron"
     WEAPON = "weapon"
+    RICE = "rice"
+    CRABS = "crabs"
+    FISH = "fish"
+    CATTLE = "cattle"
+    HORSES = "horses"
+    PIGS = "pigs"
+    CLAY = "clay"
+    CHICKENS = "chickens"
+    PEARLS = "pearls"
+    SPICE = "spice"
+    GEMS = "gems"
+    TEA = "tea"
+    ELEPHANTS = "elephants"
+
+
+# Categorization helpers for resource types
+STRATEGIC_RESOURCES = {
+    ResourceType.IRON,
+    ResourceType.WEAPON,
+    ResourceType.HORSES,
+    ResourceType.ELEPHANTS,
+}
+
+LUXURY_RESOURCES = {
+    ResourceType.GOLD,
+    ResourceType.GEMS,
+    ResourceType.PEARLS,
+    ResourceType.SPICE,
+    ResourceType.TEA,
+}
 
 
 @dataclass(frozen=True)
@@ -128,6 +158,16 @@ def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, i
             resources[ResourceType.STONE] = rng.randint(1, 4)
         if rng.random() < 0.1:
             resources[ResourceType.WOOL] = rng.randint(1, 3)
+        if rng.random() < 0.2:
+            resources[ResourceType.PIGS] = rng.randint(1, 3)
+        if rng.random() < 0.15:
+            resources[ResourceType.CHICKENS] = rng.randint(1, 3)
+        if rng.random() < 0.1:
+            resources[ResourceType.CLAY] = rng.randint(1, 2)
+        if rng.random() < 0.05:
+            resources[ResourceType.SPICE] = rng.randint(1, 1)
+        if rng.random() < 0.05:
+            resources[ResourceType.TEA] = rng.randint(1, 1)
     elif terrain == "mountains":
         resources[ResourceType.STONE] = rng.randint(5, 15)
         if rng.random() < 0.7:
@@ -136,6 +176,10 @@ def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, i
             resources[ResourceType.IRON] = rng.randint(1, 3)
         if rng.random() < 0.2:
             resources[ResourceType.GOLD] = rng.randint(1, 2)
+        if rng.random() < 0.2:
+            resources[ResourceType.GEMS] = rng.randint(1, 2)
+        if rng.random() < 0.1:
+            resources[ResourceType.CLAY] = rng.randint(1, 2)
     elif terrain == "hills":
         if rng.random() < 0.5:
             resources[ResourceType.WOOD] = rng.randint(1, 5)
@@ -147,6 +191,12 @@ def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, i
             resources[ResourceType.IRON] = rng.randint(1, 2)
         if rng.random() < 0.05:
             resources[ResourceType.GOLD] = rng.randint(1, 1)
+        if rng.random() < 0.1:
+            resources[ResourceType.CLAY] = rng.randint(1, 3)
+        if rng.random() < 0.05:
+            resources[ResourceType.HORSES] = rng.randint(1, 2)
+        if rng.random() < 0.05:
+            resources[ResourceType.GEMS] = rng.randint(1, 1)
     elif terrain == "plains":
         if rng.random() < 0.5:
             resources[ResourceType.WOOD] = rng.randint(1, 5)
@@ -156,6 +206,20 @@ def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, i
             resources[ResourceType.WHEAT] = rng.randint(1, 4)
         if rng.random() < 0.2:
             resources[ResourceType.WOOL] = rng.randint(1, 2)
+        if rng.random() < 0.4:
+            resources[ResourceType.RICE] = rng.randint(1, 3)
+        if rng.random() < 0.25:
+            resources[ResourceType.CATTLE] = rng.randint(1, 3)
+        if rng.random() < 0.15:
+            resources[ResourceType.HORSES] = rng.randint(1, 2)
+        if rng.random() < 0.2:
+            resources[ResourceType.PIGS] = rng.randint(1, 2)
+        if rng.random() < 0.25:
+            resources[ResourceType.CHICKENS] = rng.randint(1, 3)
+        if rng.random() < 0.1:
+            resources[ResourceType.CLAY] = rng.randint(1, 2)
+        if rng.random() < 0.05:
+            resources[ResourceType.ELEPHANTS] = rng.randint(1, 1)
     elif terrain == "desert":
         if rng.random() < 0.2:
             resources[ResourceType.STONE] = rng.randint(1, 3)
@@ -163,6 +227,10 @@ def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, i
             resources[ResourceType.ORE] = rng.randint(1, 2)
         if rng.random() < 0.05:
             resources[ResourceType.GOLD] = rng.randint(1, 1)
+        if rng.random() < 0.1:
+            resources[ResourceType.SPICE] = rng.randint(1, 2)
+        if rng.random() < 0.05:
+            resources[ResourceType.CLAY] = rng.randint(1, 2)
     elif terrain == "tundra":
         if rng.random() < 0.3:
             resources[ResourceType.STONE] = rng.randint(1, 4)
@@ -170,6 +238,8 @@ def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, i
             resources[ResourceType.WOOD] = rng.randint(1, 3)
         if rng.random() < 0.25:
             resources[ResourceType.WOOL] = rng.randint(1, 3)
+        if rng.random() < 0.05:
+            resources[ResourceType.CATTLE] = rng.randint(1, 2)
     elif terrain == "rainforest":
         resources[ResourceType.WOOD] = rng.randint(8, 20)
         if rng.random() < 0.3:
@@ -178,8 +248,25 @@ def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, i
             resources[ResourceType.WHEAT] = rng.randint(1, 2)
         if rng.random() < 0.1:
             resources[ResourceType.WOOL] = rng.randint(1, 2)
+        if rng.random() < 0.25:
+            resources[ResourceType.SPICE] = rng.randint(1, 2)
+        if rng.random() < 0.2:
+            resources[ResourceType.TEA] = rng.randint(1, 2)
+        if rng.random() < 0.1:
+            resources[ResourceType.ELEPHANTS] = rng.randint(1, 1)
+        if rng.random() < 0.15:
+            resources[ResourceType.PIGS] = rng.randint(1, 2)
+        if rng.random() < 0.1:
+            resources[ResourceType.CHICKENS] = rng.randint(1, 2)
+        if rng.random() < 0.1:
+            resources[ResourceType.CLAY] = rng.randint(1, 2)
     elif terrain == "water":
-        pass
+        if rng.random() < 0.5:
+            resources[ResourceType.FISH] = rng.randint(1, 5)
+        if rng.random() < 0.3:
+            resources[ResourceType.CRABS] = rng.randint(1, 3)
+        if rng.random() < 0.05:
+            resources[ResourceType.PEARLS] = rng.randint(1, 1)
 
     return resources
 
@@ -410,4 +497,6 @@ __all__ = [
     "RiverSegment",
     "World",
     "adjust_settings",
+    "STRATEGIC_RESOURCES",
+    "LUXURY_RESOURCES",
 ]


### PR DESCRIPTION
## Summary
- introduce additional ResourceType enums for various food, strategic, and luxury goods
- provide STRATEGIC_RESOURCES and LUXURY_RESOURCES helper sets
- generate new resources based on hex terrain
- test generation of strategic and luxury resources
- update persistence tests for new load_state API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e1a262ec832bb73606b4f34d58c5