### PR TITLE
Add disaster intensity setting

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -79,3 +79,16 @@ def test_raid_raises_hill(monkeypatch):
     event.apply(state, world)
     assert hex_.terrain == "mountains"
 
+
+def test_disaster_intensity_affects_flood_damage():
+    low = WorldSettings(seed=1, width=3, height=3, disaster_intensity=0.0)
+    high = WorldSettings(seed=1, width=3, height=3, disaster_intensity=1.0)
+    world_low = World(width=low.width, height=low.height, settings=low)
+    world_high = World(width=high.width, height=high.height, settings=high)
+    loc = (1, 1)
+    state_low = SettlementState(location=loc, buildings=10)
+    state_high = SettlementState(location=loc, buildings=10)
+    Flood().apply(state_low, world_low)
+    Flood().apply(state_high, world_high)
+    assert state_high.buildings < state_low.buildings
+

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -97,7 +97,7 @@ def test_offline_processing_buildings(tmp_path, monkeypatch):
     ticks = int((1003.0 - 1000.0) // persistence.TICK_DURATION)
     values = [0, 0, 0] * ticks
     monkeypatch.setattr("random.randint", lambda a, b: values.pop(0))
-    loaded = persistence.load_state(world=world, factions=[faction])
+    loaded, _ = persistence.load_state(world=world, factions=[faction])
 
     assert loaded.resources[player][ResourceType.METAL] == 4
     assert loaded.resources[player][ResourceType.ORE] == 0
@@ -162,7 +162,7 @@ def test_offline_project_completion(tmp_path, monkeypatch):
     monkeypatch.setattr(persistence.time, "time", lambda: offline_time)
     monkeypatch.setattr("random.randint", lambda a, b: 0)
 
-    loaded = persistence.load_state(world=world, factions=[faction])
+    loaded, _ = persistence.load_state(world=world, factions=[faction])
 
     assert faction.projects[0].is_complete()
     player = faction.name

--- a/world/world.py
+++ b/world/world.py
@@ -79,6 +79,7 @@ class WorldSettings:
     elevation: float = 0.5
     temperature: float = 0.5
     rainfall_intensity: float = 0.5
+    disaster_intensity: float = 0.0
     sea_level: float = 0.3
     plate_activity: float = 0.5
     base_height: float = 0.5
@@ -381,6 +382,7 @@ def adjust_settings(
     elevation: float | None = None,
     temperature: float | None = None,
     rainfall_intensity: float | None = None,
+    disaster_intensity: float | None = None,
     sea_level: float | None = None,
     plate_activity: float | None = None,
     base_height: float | None = None,
@@ -394,6 +396,8 @@ def adjust_settings(
         settings.temperature = max(0.0, min(1.0, temperature))
     if rainfall_intensity is not None:
         settings.rainfall_intensity = max(0.0, min(1.0, rainfall_intensity))
+    if disaster_intensity is not None:
+        settings.disaster_intensity = max(0.0, min(1.0, disaster_intensity))
     if sea_level is not None:
         settings.sea_level = max(0.0, min(1.0, sea_level))
     if plate_activity is not None:


### PR DESCRIPTION
## Summary
- allow customizing disaster intensity in `WorldSettings`
- incorporate disaster intensity into event severity and scheduling
- test persistence adjustments for new load_state tuple
- verify floods are harsher with high disaster intensity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e1a6ad58832b98a24cf91b093e89