### PR TITLE
Refactor world generation to use lazy noise

### DIFF
--- a/game/persistence.py
+++ b/game/persistence.py
@@ -65,9 +65,10 @@ def serialize_world(world: "World") -> Dict[str, Any]:
         "roads": [list(r.start + r.end) for r in getattr(world, "roads", [])],
         "rivers": [list(r.start + r.end) for r in getattr(world, "rivers", [])],
         "hexes": {
-            f"{q},{r}": {"flooded": h.flooded, "ruined": h.ruined}
-            for r, row in enumerate(getattr(world, "hexes", []))
-            for q, h in enumerate(row)
+            f"{h.coord[0]},{h.coord[1]}": {"flooded": h.flooded, "ruined": h.ruined}
+            for chunk in getattr(world, "chunks", {}).values()
+            for row in chunk
+            for h in row
             if h.flooded or h.ruined
         },
     }

--- a/tests/test_biomes.py
+++ b/tests/test_biomes.py
@@ -1,19 +1,22 @@
 from world.world import WorldSettings, World
-from world.generation import generate_biome_map
+from world.generation import determine_biome
 
 
-def test_temperature_and_rainfall_maps():
+def test_temperature_and_rainfall_attributes():
     settings = WorldSettings(seed=1, width=3, height=3)
     world = World(width=settings.width, height=settings.height, settings=settings)
-    assert len(world.temperature_map) == settings.height
-    assert len(world.temperature_map[0]) == settings.width
-    assert len(world.rainfall_map) == settings.height
-    assert len(world.rainfall_map[0]) == settings.width
+    for r in range(settings.height):
+        for q in range(settings.width):
+            h = world.get(q, r)
+            assert 0.0 <= h.temperature <= 1.0
+            assert 0.0 <= h.moisture <= 1.0
 
 
 def test_biome_map_used_for_terrain():
     settings = WorldSettings(seed=2, width=4, height=4)
     world = World(width=settings.width, height=settings.height, settings=settings)
-    expected = generate_biome_map(world.elevation_map, world.temperature_map, world.rainfall_map)
-    terrains = [[h.terrain for h in row] for row in world.hexes]
-    assert terrains == expected
+    for r in range(settings.height):
+        for q in range(settings.width):
+            h = world.get(q, r)
+            expected = determine_biome(h.elevation, h.temperature, h.moisture)
+            assert h.terrain == expected

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -192,8 +192,9 @@ def test_advanced_resources_generated():
 
     advanced = {ResourceType.IRON, ResourceType.GOLD, ResourceType.WHEAT, ResourceType.WOOL}
     found: set[ResourceType] = set()
-    for row in world.hexes:
-        for hex_ in row:
+    for r in range(settings.height):
+        for q in range(settings.width):
+            hex_ = world.get(q, r)
             for res in hex_.resources:
                 if res in advanced:
                     found.add(res)
@@ -209,8 +210,9 @@ def test_strategic_and_luxury_resources_generated():
     strategic_found: set[ResourceType] = set()
     luxury_found: set[ResourceType] = set()
 
-    for row in world.hexes:
-        for hex_ in row:
+    for r in range(settings.height):
+        for q in range(settings.width):
+            hex_ = world.get(q, r)
             for res in hex_.resources:
                 if res in STRATEGIC_RESOURCES:
                     strategic_found.add(res)

--- a/tests/test_rivers.py
+++ b/tests/test_rivers.py
@@ -4,4 +4,8 @@ def test_rivers_generated():
     settings = WorldSettings(seed=1, width=5, height=5, rainfall_intensity=1.0)
     world = World(width=settings.width, height=settings.height, settings=settings)
     assert len(world.rivers) > 0
-    assert any(hex_.lake for row in world.hexes for hex_ in row)
+    assert any(
+        world.get(q, r).lake
+        for r in range(settings.height)
+        for q in range(settings.width)
+    )


### PR DESCRIPTION
## Summary
- refactor `World` to generate terrain on demand using noise
- remove large precomputed climate arrays and base hex grid
- store hex data only in generated chunks and update serialization
- expose `noise_scale` and `noise_octaves` in `WorldSettings`
- update tests for lazy generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840e89050dc832ba29cc1deb64106a0