### PR TITLE
Incorporate elevation setting into map generation

### DIFF
--- a/tests/test_elevation_setting.py
+++ b/tests/test_elevation_setting.py
@@ -1,0 +1,11 @@
+from world.world import WorldSettings, World
+
+
+def test_elevation_setting_affects_elevation_map():
+    low = WorldSettings(seed=1, width=5, height=5, elevation=0.1)
+    high = WorldSettings(seed=1, width=5, height=5, elevation=0.9)
+    low_world = World(width=low.width, height=low.height, settings=low)
+    high_world = World(width=high.width, height=high.height, settings=high)
+    avg_low = sum(sum(row) for row in low_world.elevation_map) / (low.width * low.height)
+    avg_high = sum(sum(row) for row in high_world.elevation_map) / (high.width * high.height)
+    assert avg_high > avg_low

--- a/world/generation.py
+++ b/world/generation.py
@@ -93,7 +93,11 @@ def generate_elevation_map(
         row: List[float] = []
         for x in range(width):
             n = perlin_noise(x, y, settings.seed)
-            row.append(n)
+            # Adjust elevation based on the requested overall level.
+            amp = 0.5 + settings.elevation / 2
+            offset = settings.elevation - 0.5
+            val = max(0.0, min(1.0, n * amp + offset))
+            row.append(val)
         elev.append(row)
 
     apply_tectonic_plates(elev, settings)

--- a/world/world.py
+++ b/world/world.py
@@ -388,13 +388,17 @@ class World:
         """Create simple rivers flowing downhill based on precomputed elevation."""
         density = max(0.0, min(1.0, self.settings.rainfall_intensity))
         seeds = max(1, int(density * 5))
+        avg_elev = sum(sum(row) for row in self.elevation_map) / (
+            self.width * self.height
+        )
+        threshold = max(self.settings.sea_level, avg_elev)
         for _ in range(seeds):
             # choose a random high-elevation starting hex
             for _ in range(100):
                 q = self.rng.randint(0, self.width - 1)
                 r = self.rng.randint(0, self.height - 1)
                 h = self.get(q, r)
-                if h and h.elevation > self.settings.elevation * 0.7:
+                if h and h.elevation > threshold:
                     break
             else:
                 continue


### PR DESCRIPTION
## Summary
- use elevation setting as amplitude/offset when creating the elevation map
- select river sources relative to sea level and overall average elevation
- add test verifying elevation slider changes map heights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e8927a9c832ba4f645adf4084c39