### PR TITLE
Remove biome distribution and refactor event weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ python ui/faction_creation.py
 The `game.events` module provides a lightweight framework for triggering
 random events such as floods, droughts or raids during gameplay. Each
 event affects a settlement's resources, population and buildings.
-Probabilities are influenced by the biome and weather settings from the
-world generator, allowing different worlds to feel unique.
+Probabilities are influenced by configurable event weights and the
+world's weather settings, allowing different worlds to feel unique.
 
 Example usage:
 
@@ -47,7 +47,7 @@ from world.world import WorldSettings
 from game.events import EventSystem, SettlementState
 
 settings = WorldSettings()
-events = EventSystem(settings)
+events = EventSystem(settings, event_weights={"flood": 1.0, "drought": 1.0, "raid": 0.5})
 state = SettlementState()
 
 # Advance turns and print triggered events

--- a/world/world.py
+++ b/world/world.py
@@ -92,16 +92,6 @@ class WorldSettings:
     seed: int = 0
     width: int = 50
     height: int = 50
-    biome_distribution: Dict[str, float] = field(
-        default_factory=lambda: {
-            "plains": 0.3,
-            "forest": 0.25,
-            "hills": 0.2,
-            "desert": 0.15,
-            "mountains": 0.05,
-            "water": 0.05,
-        }
-    )
     weather_patterns: Dict[str, float] = field(
         default_factory=lambda: {"rain": 0.3, "dry": 0.5, "snow": 0.2}
     )
@@ -141,13 +131,6 @@ class Hex:
 def initialize_random(settings: WorldSettings) -> random.Random:
     """Create a random generator based on the provided seed."""
     return random.Random(settings.seed)
-
-
-def generate_terrain_type(rng: random.Random, settings: WorldSettings) -> str:
-    """Choose a biome based on distribution weights."""
-    biomes = list(settings.biome_distribution.keys())
-    weights = list(settings.biome_distribution.values())
-    return rng.choices(biomes, weights=weights, k=1)[0]
 
 
 def generate_resources(rng: random.Random, terrain: str) -> Dict[ResourceType, int]:


### PR DESCRIPTION
## Summary
- drop `biome_distribution` from `WorldSettings`
- remove unused `generate_terrain_type`
- let `EventSystem` accept explicit event weights
- document new usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e8917ec0832ba9a4cb17caa42207