### PR TITLE
Remove hexes cache and add hex generator

### DIFF
--- a/game/persistence.py
+++ b/game/persistence.py
@@ -65,10 +65,9 @@ def serialize_world(world: "World") -> Dict[str, Any]:
         "roads": [list(r.start + r.end) for r in getattr(world, "roads", [])],
         "rivers": [list(r.start + r.end) for r in getattr(world, "rivers", [])],
         "hexes": {
-            f"{q},{r}": {"flooded": h.flooded, "ruined": h.ruined}
-            for r, row in enumerate(getattr(world, "hexes", []))
-            for q, h in enumerate(row)
-            if h.flooded or h.ruined
+            f"{hex_.coord[0]},{hex_.coord[1]}": {"flooded": hex_.flooded, "ruined": hex_.ruined}
+            for hex_ in world.all_hexes()
+            if hex_.flooded or hex_.ruined
         },
     }
 

--- a/tests/test_biomes.py
+++ b/tests/test_biomes.py
@@ -15,5 +15,8 @@ def test_biome_map_used_for_terrain():
     settings = WorldSettings(seed=2, width=4, height=4)
     world = World(width=settings.width, height=settings.height, settings=settings)
     expected = generate_biome_map(world.elevation_map, world.temperature_map, world.rainfall_map)
-    terrains = [[h.terrain for h in row] for row in world.hexes]
+    terrains = [
+        [world.get(q, r).terrain for q in range(settings.width)]
+        for r in range(settings.height)
+    ]
     assert terrains == expected

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -192,11 +192,10 @@ def test_advanced_resources_generated():
 
     advanced = {ResourceType.IRON, ResourceType.GOLD, ResourceType.WHEAT, ResourceType.WOOL}
     found: set[ResourceType] = set()
-    for row in world.hexes:
-        for hex_ in row:
-            for res in hex_.resources:
-                if res in advanced:
-                    found.add(res)
+    for hex_ in world.all_hexes():
+        for res in hex_.resources:
+            if res in advanced:
+                found.add(res)
 
     assert any(res in found for res in advanced)
 
@@ -209,13 +208,12 @@ def test_strategic_and_luxury_resources_generated():
     strategic_found: set[ResourceType] = set()
     luxury_found: set[ResourceType] = set()
 
-    for row in world.hexes:
-        for hex_ in row:
-            for res in hex_.resources:
-                if res in STRATEGIC_RESOURCES:
-                    strategic_found.add(res)
-                if res in LUXURY_RESOURCES:
-                    luxury_found.add(res)
+    for hex_ in world.all_hexes():
+        for res in hex_.resources:
+            if res in STRATEGIC_RESOURCES:
+                strategic_found.add(res)
+            if res in LUXURY_RESOURCES:
+                luxury_found.add(res)
 
     assert strategic_found
     assert luxury_found

--- a/tests/test_rivers.py
+++ b/tests/test_rivers.py
@@ -4,4 +4,4 @@ def test_rivers_generated():
     settings = WorldSettings(seed=1, width=5, height=5, rainfall_intensity=1.0)
     world = World(width=settings.width, height=settings.height, settings=settings)
     assert len(world.rivers) > 0
-    assert any(hex_.lake for row in world.hexes for hex_ in row)
+    assert any(hex_.lake for hex_ in world.all_hexes())


### PR DESCRIPTION
## Summary
- generate all hex tiles lazily instead of storing them
- expose `World.all_hexes()`
- update persistence and tests for the new iterator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e894de6c832b8d5cf4c1c1dbc77d