### PR TITLE
Add customizable biome thresholds

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,22 @@
+import json
+import xml.etree.ElementTree as ET
+from world.world import World
+from world.export import export_resources_json, export_resources_xml
+
+
+def test_export_json(tmp_path):
+    world = World(width=3, height=3)
+    file = tmp_path / "res.json"
+    export_resources_json(world, file)
+    data = json.loads(file.read_text())
+    assert isinstance(data, list)
+
+
+def test_export_xml(tmp_path):
+    world = World(width=3, height=3)
+    file = tmp_path / "res.xml"
+    export_resources_xml(world, file)
+    tree = ET.parse(file)
+    root = tree.getroot()
+    assert root.tag == "resources"
+

--- a/ui/map_view.py
+++ b/ui/map_view.py
@@ -1,5 +1,6 @@
 import math
 import dearpygui.dearpygui as dpg
+from world.generation import BIOME_COLORS
 
 HEX_SIZE = 30
 
@@ -195,14 +196,4 @@ class MapView:
 
 
 def terrain_color(name):
-    mapping = {
-        "plains": (110, 205, 88, 255),
-        "forest": (34, 139, 34, 255),
-        "mountains": (139, 137, 137, 255),
-        "hills": (107, 142, 35, 255),
-        "desert": (237, 201, 175, 255),
-        "tundra": (220, 220, 220, 255),
-        "rainforest": (0, 100, 0, 255),
-        "water": (65, 105, 225, 255),
-    }
-    return mapping.get(name, (200, 200, 200, 255))
+    return BIOME_COLORS.get(name, (200, 200, 200, 255))

--- a/ui/world_setup.py
+++ b/ui/world_setup.py
@@ -57,6 +57,38 @@ class WorldSetupUI:
                 callback=self._update_world,
             )
             dpg.add_slider_float(
+                label="Mountain Elev",
+                tag="mountain_elev",
+                min_value=0.0,
+                max_value=1.0,
+                default_value=self.settings.mountain_elev,
+                callback=self._update_world,
+            )
+            dpg.add_slider_float(
+                label="Hill Elev",
+                tag="hill_elev",
+                min_value=0.0,
+                max_value=1.0,
+                default_value=self.settings.hill_elev,
+                callback=self._update_world,
+            )
+            dpg.add_slider_float(
+                label="Tundra Temp",
+                tag="tundra_temp",
+                min_value=0.0,
+                max_value=1.0,
+                default_value=self.settings.tundra_temp,
+                callback=self._update_world,
+            )
+            dpg.add_slider_float(
+                label="Desert Rain",
+                tag="desert_rain",
+                min_value=0.0,
+                max_value=1.0,
+                default_value=self.settings.desert_rain,
+                callback=self._update_world,
+            )
+            dpg.add_slider_float(
                 label="Tectonic Activity",
                 tag="tectonic",
                 min_value=0.0,
@@ -79,6 +111,10 @@ class WorldSetupUI:
         self.settings.sea_level = dpg.get_value("sea_level")
         self.settings.temperature = dpg.get_value("temperature")
         self.settings.moisture = dpg.get_value("moisture")
+        self.settings.mountain_elev = dpg.get_value("mountain_elev")
+        self.settings.hill_elev = dpg.get_value("hill_elev")
+        self.settings.tundra_temp = dpg.get_value("tundra_temp")
+        self.settings.desert_rain = dpg.get_value("desert_rain")
         self.settings.plate_activity = dpg.get_value("tectonic")
         self.settings.world_changes = dpg.get_value("world_changes")
 

--- a/world/__init__.py
+++ b/world/__init__.py
@@ -14,7 +14,9 @@ from .generation import (
     determine_biome,
     generate_elevation_map,
     terrain_from_elevation,
+    BIOME_COLORS,
 )
+from .export import export_resources_json, export_resources_xml
 
 __all__ = [
     "ResourceType",
@@ -30,4 +32,7 @@ __all__ = [
     "determine_biome",
     "generate_elevation_map",
     "terrain_from_elevation",
+    "BIOME_COLORS",
+    "export_resources_json",
+    "export_resources_xml",
 ]

--- a/world/export.py
+++ b/world/export.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Utilities for exporting world data in various formats."""
+
+from pathlib import Path
+import json
+import xml.etree.ElementTree as ET
+
+from .world import World, Hex, ResourceType
+
+
+def _hex_to_dict(hex_: Hex) -> dict:
+    return {
+        "coord": list(hex_.coord),
+        "terrain": hex_.terrain,
+        "resources": {r.value: amt for r, amt in hex_.resources.items()},
+    }
+
+
+def export_resources_json(world: World, path: str | Path) -> None:
+    """Export hex resource data to a JSON file."""
+    data = [_hex_to_dict(h) for h in world.all_hexes() if h.resources]
+    with open(Path(path), "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def export_resources_xml(world: World, path: str | Path) -> None:
+    """Export hex resource data to an XML file."""
+    root = ET.Element("resources")
+    for hex_ in world.all_hexes():
+        if not hex_.resources:
+            continue
+        hex_el = ET.SubElement(
+            root,
+            "hex",
+            q=str(hex_.coord[0]),
+            r=str(hex_.coord[1]),
+            terrain=hex_.terrain,
+        )
+        for rtype, amt in hex_.resources.items():
+            ET.SubElement(hex_el, "resource", type=rtype.value, amount=str(amt))
+    tree = ET.ElementTree(root)
+    tree.write(Path(path), encoding="utf-8", xml_declaration=True)
+
+
+__all__ = ["export_resources_json", "export_resources_xml"]
+

--- a/world/generation.py
+++ b/world/generation.py
@@ -4,10 +4,24 @@ from __future__ import annotations
 
 import random
 import math
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, Dict, Tuple
 
 if TYPE_CHECKING:
     from .world import WorldSettings
+
+
+# -- Visualization -----------------------------------------------------------
+
+BIOME_COLORS: Dict[str, Tuple[int, int, int, int]] = {
+    "plains": (110, 205, 88, 255),
+    "forest": (34, 139, 34, 255),
+    "mountains": (139, 137, 137, 255),
+    "hills": (107, 142, 35, 255),
+    "desert": (237, 201, 175, 255),
+    "tundra": (220, 220, 220, 255),
+    "rainforest": (0, 100, 0, 255),
+    "water": (65, 105, 225, 255),
+}
 
 
 # -- Noise utilities ---------------------------------------------------------
@@ -269,4 +283,5 @@ __all__ = [
     "generate_rainfall",
     "determine_biome",
     "generate_biome_map",
+    "BIOME_COLORS",
 ]

--- a/world/generation.py
+++ b/world/generation.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 # -- Noise utilities ---------------------------------------------------------
 
+
 def _fade(t: float) -> float:
     return t * t * t * (t * (t * 6 - 15) + 10)
 
@@ -81,6 +82,7 @@ def perlin_noise(
 
 # -- Elevation map generation ------------------------------------------------
 
+
 def generate_elevation_map(
     width: int,
     height: int,
@@ -128,7 +130,9 @@ def apply_tectonic_plates(
             dist1 = dists[1][0] if len(dists) > 1 else dist0
             ratio = dist0 / (dist0 + dist1) if dist1 > 0 else 0.0
             boundary = 1.0 - abs(0.5 - ratio) * 2.0
-            plate_height = base * settings.base_height + boundary * settings.plate_activity
+            plate_height = (
+                base * settings.base_height + boundary * settings.plate_activity
+            )
             elev[y][x] = min(1.0, max(0.0, (elev[y][x] + plate_height) / 2))
 
 
@@ -147,6 +151,7 @@ def terrain_from_elevation(
 
 
 # -- Climate and biome utilities ------------------------------------------------
+
 
 def _latitude(row: int, height: int) -> float:
     """Return normalized latitude (0 south pole -> 1 north pole)."""
@@ -207,15 +212,20 @@ def determine_biome(
     elevation: float,
     temperature: float,
     rainfall: float,
+    *,
+    mountain_elev: float = 0.8,
+    hill_elev: float = 0.6,
+    tundra_temp: float = 0.25,
+    desert_rain: float = 0.2,
 ) -> str:
     """Classify biome from elevation, temperature, and rainfall values."""
-    if elevation > 0.8:
+    if elevation > mountain_elev:
         return "mountains"
-    if elevation > 0.6:
+    if elevation > hill_elev:
         return "hills"
-    if temperature < 0.25:
+    if temperature < tundra_temp:
         return "tundra"
-    if rainfall < 0.2 and temperature > 0.5:
+    if rainfall < desert_rain and temperature > 0.5:
         return "desert"
     if rainfall > 0.7 and temperature > 0.5:
         return "rainforest"


### PR DESCRIPTION
## Summary
- make biome thresholds configurable via `WorldSettings`
- support optional threshold arguments for `determine_biome`
- pass new settings when generating terrain
- expose the thresholds in the world setup UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e896050c832ba5f3c917ee794c90