### PR TITLE
Add late-game god powers

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -23,6 +23,7 @@ from . import settings
 from world.world import World, ResourceType
 from .resources import ResourceManager
 from .models import Position, Settlement, GreatProject, Faction
+from .god_powers import ALL_POWERS, GodPower
 
 
 # Predefined templates for special high-cost projects
@@ -129,6 +130,7 @@ class Game:
         self.trade_deals: List[TradeDeal] = []
         self.truces: List[Truce] = []
         self.wars: List[DeclarationOfWar] = []
+        self.god_powers: Dict[str, GodPower] = {p.name: p for p in ALL_POWERS}
 
     def place_initial_settlement(self, x: int, y: int, name: str = "Player"):
         pos = Position(x, y)
@@ -394,6 +396,25 @@ class Game:
         # transfer from B to A
         if deal.resources_b_to_a:
             deal.faction_b.transfer_resources(deal.faction_a, deal.resources_b_to_a)
+
+    # ------------------------------------------------------------------
+    # God power utilities
+    # ------------------------------------------------------------------
+    def available_powers(self) -> List[GodPower]:
+        if not self.player_faction:
+            return []
+        completed = {p.name for p in self.player_faction.completed_projects()}
+        return [
+            p
+            for p in self.god_powers.values()
+            if p.is_unlocked(self.player_faction, completed)
+        ]
+
+    def use_power(self, name: str) -> None:
+        if name not in self.god_powers:
+            raise ValueError("Unknown power")
+        power = self.god_powers[name]
+        power.apply(self)
 
 
 def main():

--- a/game/god_powers.py
+++ b/game/god_powers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""High-level god powers that players can invoke at great expense."""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, TYPE_CHECKING, List
+
+from world.world import ResourceType
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .game import Game, Faction
+
+
+@dataclass
+class GodPower:
+    """Representation of a powerful ability unlocked late game."""
+
+    name: str
+    cost: Dict[ResourceType, int]
+    description: str
+    apply_effect: Callable[[Game], None]
+    unlock_condition: Callable[[Faction, set[str]], bool]
+
+    def is_unlocked(self, faction: Faction, completed: set[str]) -> bool:
+        return self.unlock_condition(faction, completed)
+
+    def apply(self, game: Game) -> None:
+        faction = game.player_faction
+        if faction is None:
+            raise RuntimeError("Player faction not initialized")
+
+        completed = {p.name for p in faction.completed_projects()}
+        if not self.is_unlocked(faction, completed):
+            raise ValueError(f"{self.name} not unlocked")
+
+        for res, amt in self.cost.items():
+            if faction.resources.get(res, 0) < amt:
+                raise ValueError(f"Not enough {res.value} for {self.name}")
+
+        for res, amt in self.cost.items():
+            faction.resources[res] -= amt
+        self.apply_effect(game)
+
+
+# ---------------------------------------------------------------------------
+# Power implementations
+# ---------------------------------------------------------------------------
+
+def _summon_harvest_effect(game: Game) -> None:
+    faction = game.player_faction
+    if faction:
+        faction.resources[ResourceType.FOOD] = faction.resources.get(ResourceType.FOOD, 0) + 500
+
+
+def _summon_harvest_unlock(faction: Faction, completed: set[str]) -> bool:
+    wood = faction.resources.get(ResourceType.WOOD, 0)
+    stone = faction.resources.get(ResourceType.STONE, 0)
+    return wood + stone >= 1000
+
+
+SUMMON_HARVEST = GodPower(
+    name="Summon Harvest",
+    cost={ResourceType.WOOD: 300, ResourceType.STONE: 300},
+    description="Conjure abundant crops, granting 500 food.",
+    apply_effect=_summon_harvest_effect,
+    unlock_condition=_summon_harvest_unlock,
+)
+
+
+def _quell_disaster_effect(game: Game) -> None:
+    faction = game.player_faction
+    if faction:
+        faction.citizens.count += 20
+        for res in (ResourceType.WOOD, ResourceType.STONE, ResourceType.FOOD):
+            faction.resources[res] = faction.resources.get(res, 0) + 100
+
+
+def _quell_disaster_unlock(faction: Faction, completed: set[str]) -> bool:
+    return "Sky Fortress" in completed or "Grand Cathedral" in completed
+
+
+QUELL_DISASTER = GodPower(
+    name="Quell Disaster",
+    cost={
+        ResourceType.WOOD: 200,
+        ResourceType.STONE: 200,
+        ResourceType.FOOD: 200,
+    },
+    description="Stabilize the realm, restoring people and supplies.",
+    apply_effect=_quell_disaster_effect,
+    unlock_condition=_quell_disaster_unlock,
+)
+
+
+ALL_POWERS: List[GodPower] = [SUMMON_HARVEST, QUELL_DISASTER]
+
+__all__ = ["GodPower", "ALL_POWERS", "SUMMON_HARVEST", "QUELL_DISASTER"]

--- a/tests/test_god_powers.py
+++ b/tests/test_god_powers.py
@@ -1,0 +1,70 @@
+import copy
+import os
+import sys
+import pytest
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from game.game import Game, Faction, Settlement, Position, GREAT_PROJECT_TEMPLATES
+from world.world import World, ResourceType
+
+
+def make_world():
+    w = World(width=3, height=3)
+    center = (1, 1)
+    for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
+        tile = w.get(center[0] + dq, center[1] + dr)
+        if tile:
+            tile.terrain = "plains"
+    return w
+
+
+def complete_project(faction: Faction, name: str) -> None:
+    template = copy.deepcopy(GREAT_PROJECT_TEMPLATES[name])
+    faction.start_project(template, claimed_projects=set())
+    for _ in range(template.build_time):
+        faction.progress_projects()
+
+
+def test_summon_harvest_cost_and_effect():
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+    faction = game.player_faction
+    faction.resources[ResourceType.WOOD] = 700
+    faction.resources[ResourceType.STONE] = 700
+    faction.resources[ResourceType.FOOD] = 0
+
+    assert any(p.name == "Summon Harvest" for p in game.available_powers())
+    game.use_power("Summon Harvest")
+    assert faction.resources[ResourceType.FOOD] == 500
+    assert faction.resources[ResourceType.WOOD] == 400
+    assert faction.resources[ResourceType.STONE] == 400
+
+
+def test_quell_disaster_requires_project_and_deducts_resources():
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+    faction = game.player_faction
+    faction.resources[ResourceType.WOOD] = 500
+    faction.resources[ResourceType.STONE] = 500
+    faction.resources[ResourceType.FOOD] = 500
+
+    complete_project(faction, "Sky Fortress")
+
+    assert any(p.name == "Quell Disaster" for p in game.available_powers())
+    pop_before = faction.citizens.count
+    game.use_power("Quell Disaster")
+    assert faction.citizens.count == pop_before + 20
+    assert faction.resources[ResourceType.WOOD] == 400
+    assert faction.resources[ResourceType.STONE] == 400
+    assert faction.resources[ResourceType.FOOD] == 400
+
+
+def test_power_fails_without_requirements():
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+
+    with pytest.raises(ValueError):
+        game.use_power("Summon Harvest")

--- a/ui/god_powers.py
+++ b/ui/god_powers.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Simple UI for invoking god powers using DearPyGui."""
+
+from typing import Dict
+import dearpygui.dearpygui as dpg
+
+from game.game import Game
+from game.god_powers import GodPower
+
+
+class GodPowersUI:
+    def __init__(self, game: Game) -> None:
+        self.game = game
+        dpg.create_context()
+        dpg.create_viewport(title="God Powers", width=220, height=150)
+        with dpg.window(label="God Powers", width=220, height=150, no_resize=True, no_move=True):
+            self.container = dpg.add_group()
+        dpg.set_primary_window(dpg.last_container(), True)
+        dpg.setup_dearpygui()
+        dpg.show_viewport()
+        self.buttons: Dict[str, int] = {}
+
+    def _refresh(self) -> None:
+        for power in self.game.available_powers():
+            if power.name not in self.buttons:
+                dpg.push_container_stack(self.container)
+                self.buttons[power.name] = dpg.add_button(label=power.name, callback=self._make_callback(power))
+                dpg.pop_container_stack()
+
+    def _make_callback(self, power: GodPower):
+        def cb(sender=None, app_data=None):
+            try:
+                self.game.use_power(power.name)
+            except ValueError as exc:
+                print(exc)
+        return cb
+
+    def mainloop(self) -> None:
+        while dpg.is_dearpygui_running():
+            self._refresh()
+            dpg.render_dearpygui_frame()
+        dpg.destroy_context()
+
+
+def launch(game: Game) -> None:
+    ui = GodPowersUI(game)
+    ui.mainloop()


### PR DESCRIPTION
## Summary
- add `god_powers` module defining Summon Harvest and Quell Disaster powers
- integrate powers with `Game` including availability and usage
- provide a simple DearPyGui UI to trigger powers
- test power unlocking, resource costs and effects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841332cd86c832ba9e31a2e653198b3