### PR TITLE
Add game-length scaling and progress bar

### DIFF
--- a/game/buildings.py
+++ b/game/buildings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, TYPE_CHECKING
 from world.world import ResourceType
+from . import settings
 
 if TYPE_CHECKING:
     from .models import Faction
@@ -78,7 +79,7 @@ class Building:
 class Farm(Building):
     name: str = "Farm"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 100}
+        default_factory=lambda: {ResourceType.WOOD: int(100 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 10
     resource_bonus: int = 5
@@ -89,7 +90,7 @@ class Farm(Building):
 class Mine(Building):
     name: str = "Mine"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 150}
+        default_factory=lambda: {ResourceType.WOOD: int(150 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 15
     resource_bonus: int = 10
@@ -100,7 +101,7 @@ class Mine(Building):
 class IronMine(Building):
     name: str = "IronMine"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 180}
+        default_factory=lambda: {ResourceType.WOOD: int(180 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 18
     resource_bonus: int = 2
@@ -111,7 +112,7 @@ class IronMine(Building):
 class GoldMine(Building):
     name: str = "GoldMine"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 200}
+        default_factory=lambda: {ResourceType.WOOD: int(200 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 20
     resource_bonus: int = 1
@@ -122,7 +123,7 @@ class GoldMine(Building):
 class House(Building):
     name: str = "House"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 50}
+        default_factory=lambda: {ResourceType.WOOD: int(50 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 5
     population_bonus: int = 2
@@ -133,7 +134,7 @@ class House(Building):
 class LumberMill(Building):
     name: str = "LumberMill"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 120}
+        default_factory=lambda: {ResourceType.WOOD: int(120 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 12
     resource_bonus: int = 3
@@ -144,7 +145,7 @@ class LumberMill(Building):
 class Quarry(Building):
     name: str = "Quarry"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 130}
+        default_factory=lambda: {ResourceType.WOOD: int(130 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 14
     resource_bonus: int = 2
@@ -172,7 +173,7 @@ class ProcessingBuilding(Building):
 class Smeltery(ProcessingBuilding):
     name: str = "Smeltery"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 200}
+        default_factory=lambda: {ResourceType.WOOD: int(200 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 20
     input_resource: ResourceType = ResourceType.ORE
@@ -184,7 +185,7 @@ class Smeltery(ProcessingBuilding):
 class TextileMill(ProcessingBuilding):
     name: str = "TextileMill"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 160}
+        default_factory=lambda: {ResourceType.WOOD: int(160 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 15
     input_resource: ResourceType = ResourceType.WOOD
@@ -198,7 +199,7 @@ class Mill(ProcessingBuilding):
 
     name: str = "Mill"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 120}
+        default_factory=lambda: {ResourceType.WOOD: int(120 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 10
     input_resource: ResourceType = ResourceType.WHEAT
@@ -212,7 +213,7 @@ class Bakery(ProcessingBuilding):
 
     name: str = "Bakery"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 150}
+        default_factory=lambda: {ResourceType.WOOD: int(150 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 12
     input_resource: ResourceType = ResourceType.FLOUR
@@ -226,7 +227,7 @@ class Forge(ProcessingBuilding):
 
     name: str = "Forge"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 220}
+        default_factory=lambda: {ResourceType.WOOD: int(220 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 20
     input_resource: ResourceType = ResourceType.IRON
@@ -240,7 +241,7 @@ class Tailor(ProcessingBuilding):
 
     name: str = "Tailor"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 160}
+        default_factory=lambda: {ResourceType.WOOD: int(160 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 15
     input_resource: ResourceType = ResourceType.WOOL
@@ -254,7 +255,7 @@ class Sawmill(ProcessingBuilding):
 
     name: str = "Sawmill"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 140}
+        default_factory=lambda: {ResourceType.WOOD: int(140 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 12
     input_resource: ResourceType = ResourceType.WOOD
@@ -268,7 +269,7 @@ class Mason(ProcessingBuilding):
 
     name: str = "Mason"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 160}
+        default_factory=lambda: {ResourceType.WOOD: int(160 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 14
     input_resource: ResourceType = ResourceType.STONE
@@ -282,7 +283,7 @@ class SoupKitchen(ProcessingBuilding):
 
     name: str = "SoupKitchen"
     construction_cost: Dict[ResourceType, int] = field(
-        default_factory=lambda: {ResourceType.WOOD: 110}
+        default_factory=lambda: {ResourceType.WOOD: int(110 * settings.SCALE_FACTOR)}
     )
     upkeep: int = 8
     input_resource: ResourceType = ResourceType.VEGETABLE

--- a/game/game.py
+++ b/game/game.py
@@ -29,13 +29,13 @@ from .models import Position, Settlement, GreatProject, Faction
 GREAT_PROJECT_TEMPLATES: Dict[str, GreatProject] = {
     "Grand Cathedral": GreatProject(
         name="Grand Cathedral",
-        build_time=5,
+        build_time=int(5 * settings.SCALE_FACTOR),
         victory_points=10,
         bonus="Increases faith across the realm",
     ),
     "Sky Fortress": GreatProject(
         name="Sky Fortress",
-        build_time=8,
+        build_time=int(8 * settings.SCALE_FACTOR),
         victory_points=15,
         bonus="Provides unmatched military power",
     ),
@@ -283,7 +283,7 @@ class Game:
 
         for faction in self.map.factions:
             # 1. Generate base food from population
-            food_gain = faction.citizens.count // 2
+            food_gain = int((faction.citizens.count // 2) * settings.SCALE_FACTOR)
             faction.resources[ResourceType.FOOD] = (
                 faction.resources.get(ResourceType.FOOD, 0) + food_gain
             )

--- a/game/resources.py
+++ b/game/resources.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, TYPE_CHECKING
 
 from world.world import World, Hex, ResourceType
+from . import settings
 
 if TYPE_CHECKING:
     from .game import Position, Faction
@@ -59,7 +60,7 @@ class ResourceManager:
                 if getattr(b, "resource_type", None) == res_type
             )
             # Limit gathered amount by remaining workers plus any building bonus
-            gathered = min(amount, workers_remaining + bonus)
+            gathered = int(min(amount, workers_remaining + bonus) * settings.SCALE_FACTOR)
             if res_type not in resources:
                 resources[res_type] = 0
             resources[res_type] += gathered

--- a/game/settings.py
+++ b/game/settings.py
@@ -8,3 +8,21 @@ MAP_SIZE = (10, 10)
 
 # Minimum distance from player's settlement to spawn AI
 MIN_DISTANCE_FROM_PLAYER = 2
+
+# Duration of one game tick in seconds
+TICK_SECONDS = 1
+
+# Desired total game length in seconds. Tuning this value scales
+# resource generation rates, building costs and project build times
+# so that typical progress peaks around this duration.
+TARGET_GAME_LENGTH = 600
+
+# Baseline length used when numbers were originally balanced.  The
+# scaling factor stays 1.0 with the default target above.
+_BASE_GAME_LENGTH = 600
+
+# Number of ticks expected for a full game at the target length
+TARGET_TICKS = int(TARGET_GAME_LENGTH // TICK_SECONDS)
+
+# Universal scaling factor applied to economic values
+SCALE_FACTOR = TARGET_GAME_LENGTH / _BASE_GAME_LENGTH

--- a/ui/map_view.py
+++ b/ui/map_view.py
@@ -1,6 +1,8 @@
 import math
+import time
 import dearpygui.dearpygui as dpg
 from world.generation import BIOME_COLORS
+from game import settings
 
 HEX_SIZE = 30
 
@@ -85,9 +87,12 @@ class Camera:
 
 
 class MapView:
-    def __init__(self, world, size=(800, 600)):
+    def __init__(self, world, size=(800, 600), *, show_progress=False, total_ticks=None):
         self.world = world
         self.size = size
+        self.show_progress = show_progress
+        self.total_ticks = total_ticks or settings.TARGET_TICKS
+        self.start_time = time.time() if show_progress else None
         self.camera = Camera(*size)
         self.road_mode = False
         self.road_start = None
@@ -97,6 +102,8 @@ class MapView:
         dpg.create_context()
         dpg.create_viewport(title="Map View", width=size[0], height=size[1])
         with dpg.window(tag="_map_window", width=size[0], height=size[1], no_move=True, no_resize=True, no_title_bar=True):
+            if show_progress:
+                self.progress = dpg.add_progress_bar(label="0%", width=size[0], default_value=0.0)
             self.canvas = dpg.add_drawlist(width=size[0], height=size[1], tag="_canvas")
         dpg.set_primary_window("_map_window", True)
         with dpg.handler_registry():
@@ -190,6 +197,12 @@ class MapView:
     def run(self):
         while dpg.is_dearpygui_running():
             self.draw_map()
+            if self.show_progress:
+                elapsed = time.time() - self.start_time
+                total = self.total_ticks * settings.TICK_SECONDS
+                fraction = min(elapsed / total, 1.0)
+                dpg.set_value(self.progress, fraction)
+                dpg.set_item_label(self.progress, f"{int(elapsed)}s / {int(total)}s")
             dpg.render_dearpygui_frame()
         dpg.destroy_context()
         return self.result


### PR DESCRIPTION
## Summary
- support tuning overall game duration in `settings`
- scale building costs, resource gathering and project build times with new constant
- add optional progress bar to `MapView` UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841332f1010832b8d704d2992f11a95