### PR TITLE
Add late-game god power cooldowns

### DIFF
--- a/game/god_powers.py
+++ b/game/god_powers.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""High-level god powers that players can invoke at great expense."""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, TYPE_CHECKING, List
+
+from world.world import ResourceType
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .game import Game, Faction
+
+
+@dataclass
+class GodPower:
+    """Representation of a powerful ability unlocked late game."""
+
+    name: str
+    cost: Dict[ResourceType, int]
+    description: str
+    apply_effect: Callable[[Game], None]
+    unlock_condition: Callable[[Faction, set[str]], bool]
+    cooldown: int = 0
+
+    def is_unlocked(self, faction: Faction, completed: set[str]) -> bool:
+        return self.unlock_condition(faction, completed)
+
+    def apply(self, game: Game) -> None:
+        faction = game.player_faction
+        if faction is None:
+            raise RuntimeError("Player faction not initialized")
+
+        completed = {p.name for p in faction.completed_projects()}
+        if not self.is_unlocked(faction, completed):
+            raise ValueError(f"{self.name} not unlocked")
+
+        for res, amt in self.cost.items():
+            if faction.resources.get(res, 0) < amt:
+                raise ValueError(f"Not enough {res.value} for {self.name}")
+
+        for res, amt in self.cost.items():
+            faction.resources[res] -= amt
+        self.apply_effect(game)
+
+
+# ---------------------------------------------------------------------------
+# Power implementations
+# ---------------------------------------------------------------------------
+
+def _summon_harvest_effect(game: Game) -> None:
+    faction = game.player_faction
+    if faction:
+        faction.resources[ResourceType.FOOD] = faction.resources.get(ResourceType.FOOD, 0) + 500
+
+
+def _summon_harvest_unlock(faction: Faction, completed: set[str]) -> bool:
+    wood = faction.resources.get(ResourceType.WOOD, 0)
+    stone = faction.resources.get(ResourceType.STONE, 0)
+    return wood + stone >= 1000
+
+
+SUMMON_HARVEST = GodPower(
+    name="Summon Harvest",
+    cost={ResourceType.WOOD: 300, ResourceType.STONE: 300},
+    description="Conjure abundant crops, granting 500 food.",
+    apply_effect=_summon_harvest_effect,
+    unlock_condition=_summon_harvest_unlock,
+    cooldown=3,
+)
+
+
+def _quell_disaster_effect(game: Game) -> None:
+    faction = game.player_faction
+    if faction:
+        faction.citizens.count += 20
+        for res in (ResourceType.WOOD, ResourceType.STONE, ResourceType.FOOD):
+            faction.resources[res] = faction.resources.get(res, 0) + 100
+
+
+def _quell_disaster_unlock(faction: Faction, completed: set[str]) -> bool:
+    return "Sky Fortress" in completed or "Grand Cathedral" in completed
+
+
+QUELL_DISASTER = GodPower(
+    name="Quell Disaster",
+    cost={
+        ResourceType.WOOD: 200,
+        ResourceType.STONE: 200,
+        ResourceType.FOOD: 200,
+    },
+    description="Stabilize the realm, restoring people and supplies.",
+    apply_effect=_quell_disaster_effect,
+    unlock_condition=_quell_disaster_unlock,
+    cooldown=5,
+)
+
+
+ALL_POWERS: List[GodPower] = [SUMMON_HARVEST, QUELL_DISASTER]
+
+__all__ = ["GodPower", "ALL_POWERS", "SUMMON_HARVEST", "QUELL_DISASTER"]

--- a/game/persistence.py
+++ b/game/persistence.py
@@ -28,6 +28,7 @@ class GameState:
     world: Dict[str, Any] = field(default_factory=dict)
     factions: Dict[str, Any] = field(default_factory=dict)
     turn: int = 0
+    cooldowns: Dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -143,6 +144,7 @@ def simulate_tick(
     factions: List["Faction"],
     pop_mgr: FactionManager,
     res_mgr: ResourceManager,
+    cooldowns: Dict[str, int] | None = None,
 ) -> None:
     """Advance one tick for offline gains."""
     pop_mgr.tick()
@@ -155,6 +157,10 @@ def simulate_tick(
         else:
             res_mgr.data[fac.name] = fac.resources.copy()
     res_mgr.tick(factions)
+    if cooldowns is not None:
+        for name in list(cooldowns.keys()):
+            if cooldowns[name] > 0:
+                cooldowns[name] -= 1
 
 
 def apply_offline_gains(
@@ -174,7 +180,7 @@ def apply_offline_gains(
         res_mgr = ResourceManager(world, state.resources)
         pop_mgr = FactionManager(factions)
         for _ in range(elapsed):
-            simulate_tick(factions, pop_mgr, res_mgr)
+            simulate_tick(factions, pop_mgr, res_mgr, state.cooldowns)
             for fac in factions:
                 fac.progress_projects()
 
@@ -210,6 +216,11 @@ def load_state(
             data = json.load(f)
 
         resources = deserialize_resources(data.get("resources", {}))
+        elapsed = int((now - data.get("timestamp", now)) // TICK_DURATION)
+        cooldowns_raw = data.get("cooldowns", {})
+        cooldowns = {
+            str(k): max(0, int(v) - elapsed) for k, v in cooldowns_raw.items()
+        }
         state = GameState(
             timestamp=data.get("timestamp", now),
             resources=resources,
@@ -218,6 +229,7 @@ def load_state(
             world=data.get("world", {}),
             factions=deserialize_factions(data.get("factions", {})),
             turn=int(data.get("turn", 0)),
+            cooldowns=cooldowns,
         )
 
         # If a World instance was passed, apply saved world data into it
@@ -250,5 +262,6 @@ def save_state(state: GameState) -> None:
             "world": state.world,
             "factions": state.factions,
             "turn": state.turn,
+            "cooldowns": {k: int(v) for k, v in state.cooldowns.items()},
         }
         json.dump(data, f)

--- a/tests/test_god_powers.py
+++ b/tests/test_god_powers.py
@@ -1,0 +1,97 @@
+import copy
+import os
+import sys
+import time
+import pytest
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from game.game import Game, Faction, Settlement, Position, GREAT_PROJECT_TEMPLATES
+import game.persistence as persistence
+from game.persistence import GameState, load_state
+from world.world import World, ResourceType
+
+
+def make_world():
+    w = World(width=3, height=3)
+    center = (1, 1)
+    for dq, dr in [(1, 0), (-1, 0), (0, 1), (0, -1), (1, -1), (-1, 1)]:
+        tile = w.get(center[0] + dq, center[1] + dr)
+        if tile:
+            tile.terrain = "plains"
+    return w
+
+
+def complete_project(faction: Faction, name: str) -> None:
+    template = copy.deepcopy(GREAT_PROJECT_TEMPLATES[name])
+    faction.start_project(template, claimed_projects=set())
+    for _ in range(template.build_time):
+        faction.progress_projects()
+
+
+def test_summon_harvest_cost_and_effect():
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+    faction = game.player_faction
+    faction.resources[ResourceType.WOOD] = 700
+    faction.resources[ResourceType.STONE] = 700
+    faction.resources[ResourceType.FOOD] = 0
+
+    assert any(p.name == "Summon Harvest" for p in game.available_powers())
+    game.use_power("Summon Harvest")
+    assert faction.resources[ResourceType.FOOD] == 500
+    assert faction.resources[ResourceType.WOOD] == 400
+    assert faction.resources[ResourceType.STONE] == 400
+
+
+def test_quell_disaster_requires_project_and_deducts_resources():
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+    faction = game.player_faction
+    faction.resources[ResourceType.WOOD] = 500
+    faction.resources[ResourceType.STONE] = 500
+    faction.resources[ResourceType.FOOD] = 500
+
+    complete_project(faction, "Sky Fortress")
+
+    assert any(p.name == "Quell Disaster" for p in game.available_powers())
+    pop_before = faction.citizens.count
+    game.use_power("Quell Disaster")
+    assert faction.citizens.count == pop_before + 20
+    assert faction.resources[ResourceType.WOOD] == 400
+    assert faction.resources[ResourceType.STONE] == 400
+    assert faction.resources[ResourceType.FOOD] == 400
+
+
+def test_power_fails_without_requirements():
+    world = make_world()
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+
+    with pytest.raises(ValueError):
+        game.use_power("Summon Harvest")
+
+
+def test_power_cooldown_and_persistence(tmp_path, monkeypatch):
+    world = make_world()
+    tmp_file = tmp_path / "save.json"
+    monkeypatch.setattr(persistence, "SAVE_FILE", tmp_file)
+    game = Game(world=world, state=GameState(timestamp=time.time(), resources={}, population=0))
+    game.place_initial_settlement(1, 1)
+    fac = game.player_faction
+    fac.resources[ResourceType.WOOD] = 700
+    fac.resources[ResourceType.STONE] = 700
+
+    game.use_power("Summon Harvest")
+    assert game.power_cooldowns["Summon Harvest"] == 3
+    game.tick()
+    assert game.power_cooldowns["Summon Harvest"] == 2
+    game.save()
+
+    # Load new game from saved state
+    new_state, _ = load_state()
+    new_game = Game(state=new_state, world=world)
+    new_game.place_initial_settlement(1, 1)
+    new_game.begin()
+    assert new_game.power_cooldowns["Summon Harvest"] <= 2

--- a/ui/god_powers.py
+++ b/ui/god_powers.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Simple UI for invoking god powers using DearPyGui."""
+
+from typing import Dict
+import dearpygui.dearpygui as dpg
+
+from game.game import Game
+from game.god_powers import GodPower
+
+
+class GodPowersUI:
+    def __init__(self, game: Game) -> None:
+        self.game = game
+        dpg.create_context()
+        dpg.create_viewport(title="God Powers", width=220, height=150)
+        with dpg.window(label="God Powers", width=220, height=150, no_resize=True, no_move=True):
+            self.container = dpg.add_group()
+        dpg.set_primary_window(dpg.last_container(), True)
+        dpg.setup_dearpygui()
+        dpg.show_viewport()
+        self.buttons: Dict[str, int] = {}
+
+    def _refresh(self) -> None:
+        for power in self.game.god_powers.values():
+            label = f"{power.name}"
+            if power.name not in self.buttons:
+                dpg.push_container_stack(self.container)
+                self.buttons[power.name] = dpg.add_button(
+                    label=label,
+                    callback=self._make_callback(power),
+                )
+                dpg.add_tooltip(self.buttons[power.name], label=power.description)
+                dpg.pop_container_stack()
+            # update enabled state
+            enabled = (
+                power in self.game.available_powers()
+                and self.game.power_cooldowns.get(power.name, 0) <= 0
+            )
+            dpg.configure_item(self.buttons[power.name], enabled=enabled)
+            if enabled:
+                dpg.set_item_label(
+                    self.buttons[power.name],
+                    f"{power.name} ({power.cooldown}t cd)"
+                )
+
+    def _make_callback(self, power: GodPower):
+        def cb(sender=None, app_data=None):
+            try:
+                self.game.use_power(power.name)
+            except ValueError as exc:
+                print(exc)
+        return cb
+
+    def mainloop(self) -> None:
+        while dpg.is_dearpygui_running():
+            self._refresh()
+            dpg.render_dearpygui_frame()
+        dpg.destroy_context()
+
+
+def launch(game: Game) -> None:
+    ui = GodPowersUI(game)
+    ui.mainloop()


### PR DESCRIPTION
## Summary
- add cooldown parameter to `GodPower` abilities
- track cooldowns in `Game` and persist them in save files
- decrement cooldowns each tick and after advancing turns
- update UI to show descriptions and cooldown state
- test cooldown logic and persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841332cd86c832ba9e31a2e653198b3