### PR TITLE
Support infinite world chunks

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -420,10 +420,15 @@ class Game:
                 )
                 continue
 
-            if not (0 <= sx < self.world.width and 0 <= sy < self.world.height):
+            if (
+                not self.world.settings.infinite
+                and not (0 <= sx < self.world.width and 0 <= sy < self.world.height)
+            ):
                 logger.warning(
                     "Saved settlement for faction %r out of bounds: (%d, %d). Clamping.",
-                    fname, sx, sy
+                    fname,
+                    sx,
+                    sy,
                 )
                 sx = max(0, min(self.world.width - 1, sx))
                 sy = max(0, min(self.world.height - 1, sy))

--- a/tests/test_infinite_world.py
+++ b/tests/test_infinite_world.py
@@ -1,0 +1,41 @@
+import random
+from world.world import World, WorldSettings
+from game.game import Game
+
+
+def test_get_beyond_bounds_infinite():
+    settings = WorldSettings(seed=1, width=3, height=3, infinite=True)
+    world = World(width=settings.width, height=settings.height, settings=settings)
+    hex_ = world.get(10, 10)
+    assert hex_ is not None
+    assert hex_.coord == (10, 10)
+
+
+def test_deserialize_faction_outside_bounds_infinite():
+    settings = WorldSettings(seed=1, width=3, height=3, infinite=True)
+    world = World(width=settings.width, height=settings.height, settings=settings)
+    game = Game(world=world)
+    game.place_initial_settlement(0, 0)
+    player = game.player_faction.name
+
+    game.state.factions = {
+        player: {
+            "citizens": 10,
+            "workers": 0,
+            "units": 0,
+            "buildings": [],
+            "projects": [],
+            "settlement": {"name": "Home", "position": {"x": 5, "y": 5}},
+        }
+    }
+    game.state.resources = {player: {}}
+    game.state.world = {
+        "settings": {"seed": 1, "width": 3, "height": 3, "infinite": True},
+        "hexes": {},
+    }
+
+    game.map.factions = []
+    game._restore_factions_from_state()
+    restored = next(f for f in game.map.factions if f.name == player)
+    assert restored.settlement.position.x == 5
+    assert restored.settlement.position.y == 5

--- a/world/settings.py
+++ b/world/settings.py
@@ -27,6 +27,7 @@ class WorldSettings:
     hill_elev: float = 0.6
     tundra_temp: float = 0.25
     desert_rain: float = 0.2
+    infinite: bool = False
 
 
 __all__ = ["WorldSettings"]


### PR DESCRIPTION
## Summary
- toggle world infinity via `WorldSettings.infinite`
- allow `World.get` to generate chunks outside map bounds when infinite
- relax neighbor and faction deserialization bounds
- add regression tests for infinite worlds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684200fa6a8c832ba5539d9715f73de0