### PR TITLE
Add fantasy terrain overlays

### DIFF
--- a/tests/test_fantasy.py
+++ b/tests/test_fantasy.py
@@ -1,0 +1,8 @@
+from world.world import WorldSettings, World
+
+
+def test_fantasy_features_applied():
+    settings = WorldSettings(seed=5, width=5, height=5, fantasy_level=1.0)
+    world = World(width=settings.width, height=settings.height, settings=settings)
+    terrains = {world.get(q, r).terrain for r in range(settings.height) for q in range(settings.width)}
+    assert "floating_island" in terrains or "crystal_forest" in terrains

--- a/ui/world_setup.py
+++ b/ui/world_setup.py
@@ -136,6 +136,14 @@ class WorldSetupUI:
                 default_value=self.settings.base_height,
                 callback=self._update_world,
             )
+            dpg.add_slider_float(
+                label="Fantasy Level",
+                tag="fantasy_level",
+                min_value=0.0,
+                max_value=1.0,
+                default_value=self.settings.fantasy_level,
+                callback=self._update_world,
+            )
             dpg.add_checkbox(
                 label="World Changes",
                 tag="world_changes",
@@ -166,6 +174,9 @@ class WorldSetupUI:
         )
         self.settings.base_height = max(
             0.0, min(1.0, dpg.get_value("base_height"))
+        )
+        self.settings.fantasy_level = max(
+            0.0, min(1.0, dpg.get_value("fantasy_level"))
         )
         self.settings.world_changes = dpg.get_value("world_changes")
 

--- a/world/__init__.py
+++ b/world/__init__.py
@@ -12,6 +12,11 @@ from .generation import (
     BIOME_COLORS,
 )
 from .export import export_resources_json, export_resources_xml
+from .fantasy import (
+    add_floating_islands,
+    add_crystal_forests,
+    apply_fantasy_overlays,
+)
 
 __all__ = [
     "ResourceType",
@@ -30,4 +35,7 @@ __all__ = [
     "BIOME_COLORS",
     "export_resources_json",
     "export_resources_xml",
+    "add_floating_islands",
+    "add_crystal_forests",
+    "apply_fantasy_overlays",
 ]

--- a/world/fantasy.py
+++ b/world/fantasy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Fantasy terrain generators like floating islands and crystal forests."""
+
+import random
+from typing import Iterable
+
+from .hex import Hex
+
+
+def add_floating_islands(hexes: Iterable[Hex], level: float, *, rng: random.Random | None = None) -> None:
+    """Convert some high elevation tiles into floating islands."""
+    if level <= 0:
+        return
+    rng = rng or random.Random(42)
+    candidates = [h for h in hexes if h.elevation > 0.6 and h.terrain != "water"]
+    if not candidates:
+        candidates = [h for h in hexes if h.terrain != "water"]
+    count = max(1, int(len(candidates) * 0.05 * level))
+    for h in rng.sample(candidates, min(len(candidates), count)):
+        h.terrain = "floating_island"
+
+
+def add_crystal_forests(hexes: Iterable[Hex], level: float, *, rng: random.Random | None = None) -> None:
+    """Transform some forests or plains into crystal forests."""
+    if level <= 0:
+        return
+    rng = rng or random.Random(99)
+    candidates = [h for h in hexes if h.terrain in {"forest", "plains"}]
+    if not candidates:
+        candidates = [h for h in hexes if h.terrain != "water"]
+    count = max(1, int(len(candidates) * 0.1 * level))
+    for h in rng.sample(candidates, min(len(candidates), count)):
+        h.terrain = "crystal_forest"
+
+
+def apply_fantasy_overlays(hexes: Iterable[Hex], level: float) -> None:
+    """Apply all fantasy overlays based on the given level."""
+    if level <= 0:
+        return
+    hex_list = list(hexes)
+    add_floating_islands(hex_list, level)
+    add_crystal_forests(hex_list, level)
+
+
+__all__ = ["add_floating_islands", "add_crystal_forests", "apply_fantasy_overlays"]

--- a/world/generation.py
+++ b/world/generation.py
@@ -21,6 +21,8 @@ BIOME_COLORS: Dict[str, Tuple[int, int, int, int]] = {
     "tundra": (220, 220, 220, 255),
     "rainforest": (0, 100, 0, 255),
     "water": (65, 105, 225, 255),
+    "floating_island": (186, 85, 211, 255),
+    "crystal_forest": (0, 255, 255, 255),
 }
 
 

--- a/world/settings.py
+++ b/world/settings.py
@@ -27,6 +27,7 @@ class WorldSettings:
     hill_elev: float = 0.6
     tundra_temp: float = 0.25
     desert_rain: float = 0.2
+    fantasy_level: float = 0.0
 
 
 __all__ = ["WorldSettings"]

--- a/world/world.py
+++ b/world/world.py
@@ -14,6 +14,7 @@ from .resource_types import ResourceType, STRATEGIC_RESOURCES, LUXURY_RESOURCES
 from .resources import generate_resources
 from .hex import Hex, Coordinate
 from .settings import WorldSettings
+from .fantasy import apply_fantasy_overlays
 
 @dataclass(frozen=True)
 class Road:
@@ -108,6 +109,8 @@ class World:
 
         self._plate_centers = self._init_plates()
         self._generate_rivers()
+        if self.settings.fantasy_level > 0:
+            apply_fantasy_overlays(self.all_hexes(), self.settings.fantasy_level)
 
     @property
     def width(self) -> int:


### PR DESCRIPTION
## Summary
- add generators for floating islands and crystal forests
- support a new `fantasy_level` setting
- call overlays when creating a world
- visualize fantasy terrain types
- expose `fantasy_level` slider in world setup UI
- test fantasy feature generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684200fc27d0832b8144cf8d843fdf3a