### PR TITLE
Add new resource types and coverage tests

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -12,6 +12,7 @@ from world.world import (
     STRATEGIC_RESOURCES,
     LUXURY_RESOURCES,
 )
+from world.resources import RESOURCE_RULES
 from game.resources import ResourceManager
 from game.buildings import Farm, LumberMill, Quarry, Mine
 
@@ -239,3 +240,35 @@ def test_strategic_and_luxury_resources_generated():
 
     assert strategic_found
     assert luxury_found
+
+
+def test_all_resource_types_can_generate():
+    expected = {rule[0] for rules in RESOURCE_RULES.values() for rule in rules}
+    found: set[ResourceType] = set()
+    base = WorldSettings(
+        seed=0,
+        width=20,
+        height=20,
+        moisture=1.0,
+        temperature=1.0,
+        rainfall_intensity=5,
+        sea_level=0.3,
+    )
+
+    for seed in range(30):
+        s = WorldSettings(
+            seed=seed,
+            width=base.width,
+            height=base.height,
+            moisture=base.moisture,
+            temperature=base.temperature,
+            rainfall_intensity=base.rainfall_intensity,
+            sea_level=base.sea_level,
+        )
+        world = World(width=s.width, height=s.height, settings=s)
+        for hex_ in world.all_hexes():
+            found.update(hex_.resources.keys())
+        if expected.issubset(found):
+            break
+
+    assert expected.issubset(found)

--- a/world/resource_types.py
+++ b/world/resource_types.py
@@ -41,6 +41,11 @@ class ResourceType(Enum):
     GEMS = "gems"
     TEA = "tea"
     ELEPHANTS = "elephants"
+    COAL = "coal"
+    COPPER = "copper"
+    SILVER = "silver"
+    SALT = "salt"
+    COFFEE = "coffee"
 
 
 STRATEGIC_RESOURCES: Set[ResourceType] = {
@@ -48,6 +53,7 @@ STRATEGIC_RESOURCES: Set[ResourceType] = {
     ResourceType.WEAPON,
     ResourceType.HORSES,
     ResourceType.ELEPHANTS,
+    ResourceType.COAL,
 }
 
 LUXURY_RESOURCES: Set[ResourceType] = {
@@ -56,6 +62,9 @@ LUXURY_RESOURCES: Set[ResourceType] = {
     ResourceType.PEARLS,
     ResourceType.SPICE,
     ResourceType.TEA,
+    ResourceType.SILVER,
+    ResourceType.SALT,
+    ResourceType.COFFEE,
 }
 
 __all__ = [

--- a/world/resources.py
+++ b/world/resources.py
@@ -19,6 +19,9 @@ RESOURCE_RULES: Dict[str, List[Tuple[ResourceType, int, int, float]]] = {
         (ResourceType.CLAY, 1, 2, 0.1),
         (ResourceType.SPICE, 1, 1, 0.05),
         (ResourceType.TEA, 1, 1, 0.05),
+        (ResourceType.COPPER, 1, 1, 0.05),
+        (ResourceType.VEGETABLE, 1, 2, 0.05),
+        (ResourceType.COFFEE, 1, 1, 0.05),
     ],
     "mountains": [
         (ResourceType.STONE, 5, 15, 1.0),
@@ -27,6 +30,9 @@ RESOURCE_RULES: Dict[str, List[Tuple[ResourceType, int, int, float]]] = {
         (ResourceType.GOLD, 1, 2, 0.2),
         (ResourceType.GEMS, 1, 2, 0.2),
         (ResourceType.CLAY, 1, 2, 0.1),
+        (ResourceType.COAL, 1, 3, 0.3),
+        (ResourceType.COPPER, 1, 3, 0.4),
+        (ResourceType.SILVER, 1, 2, 0.2),
     ],
     "hills": [
         (ResourceType.WOOD, 1, 5, 0.5),
@@ -37,6 +43,9 @@ RESOURCE_RULES: Dict[str, List[Tuple[ResourceType, int, int, float]]] = {
         (ResourceType.CLAY, 1, 3, 0.1),
         (ResourceType.HORSES, 1, 2, 0.05),
         (ResourceType.GEMS, 1, 1, 0.05),
+        (ResourceType.COAL, 1, 2, 0.2),
+        (ResourceType.COPPER, 1, 3, 0.3),
+        (ResourceType.SILVER, 1, 1, 0.1),
     ],
     "plains": [
         (ResourceType.WOOD, 1, 5, 0.5),
@@ -50,6 +59,9 @@ RESOURCE_RULES: Dict[str, List[Tuple[ResourceType, int, int, float]]] = {
         (ResourceType.CHICKENS, 1, 3, 0.25),
         (ResourceType.CLAY, 1, 2, 0.1),
         (ResourceType.ELEPHANTS, 1, 1, 0.05),
+        (ResourceType.SALT, 1, 1, 0.05),
+        (ResourceType.COPPER, 1, 2, 0.1),
+        (ResourceType.VEGETABLE, 1, 2, 0.05),
     ],
     "desert": [
         (ResourceType.STONE, 1, 3, 0.2),
@@ -57,6 +69,7 @@ RESOURCE_RULES: Dict[str, List[Tuple[ResourceType, int, int, float]]] = {
         (ResourceType.GOLD, 1, 1, 0.05),
         (ResourceType.SPICE, 1, 2, 0.1),
         (ResourceType.CLAY, 1, 2, 0.05),
+        (ResourceType.SALT, 1, 2, 0.15),
     ],
     "tundra": [
         (ResourceType.STONE, 1, 4, 0.3),
@@ -75,6 +88,7 @@ RESOURCE_RULES: Dict[str, List[Tuple[ResourceType, int, int, float]]] = {
         (ResourceType.PIGS, 1, 2, 0.15),
         (ResourceType.CHICKENS, 1, 2, 0.1),
         (ResourceType.CLAY, 1, 2, 0.1),
+        (ResourceType.COFFEE, 1, 2, 0.2),
     ],
     "water": [
         (ResourceType.FISH, 1, 5, 0.5),

--- a/world/world.py
+++ b/world/world.py
@@ -230,7 +230,7 @@ class World:
         coords = sorted(flow.keys(), key=lambda c: self.get(*c).elevation, reverse=True)
         for c in coords:
             d = downhill[c]
-            if d:
+            if d and d in flow:
                 flow[d] += flow[c]
 
         for c, f in flow.items():
@@ -253,6 +253,9 @@ class World:
                     if not hex_c.lake:
                         self.lakes.append(c)
                         hex_c.lake = True
+                        hex_c.terrain = "water"
+                        rng = random.Random(hash((c, self.settings.seed, "water")))
+                        hex_c.resources = generate_resources(rng, "water")
 
     def all_hexes(self) -> Iterable[Hex]:
         for r in range(self.height):


### PR DESCRIPTION
## Summary
- expand `ResourceType` with coal, copper, silver, salt and coffee
- categorize new resources as strategic/luxury
- distribute new resources across biomes
- regenerate lake tiles with water resources
- add test ensuring every resource type from `RESOURCE_RULES` can spawn

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842056b5d44832bbc5c44d78b7fc844