### PR TITLE
Improve worker assignment toggling

### DIFF
--- a/game/population.py
+++ b/game/population.py
@@ -52,6 +52,12 @@ class FactionManager:
         if faction not in self.factions:
             self.factions.append(faction)
 
+    def toggle_assignment(self, faction: Faction, manual: bool, level: str | None = None) -> None:
+        """Switch a faction between manual and automated worker assignment."""
+        if faction not in self.factions:
+            raise ValueError("Faction not managed")
+        faction.toggle_manual_assignment(manual, level)
+
     def assign_workers(self, faction: Faction, number: int) -> int:
         """Assign available citizens as workers."""
         available = faction.workers.available(faction.citizens.count)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -127,16 +127,21 @@ def test_manual_assignment_yields_more_over_time(monkeypatch):
 
     manual_game = Game(world=world)
     manual_game.place_initial_settlement(1, 1)
-    manual_game.player_faction.manual_assignment = True
+    manual_game.faction_manager.toggle_assignment(
+        manual_game.player_faction, True
+    )
     manual_game.player_faction.workers.assigned = manual_game.player_faction.citizens.count
 
     auto_game = Game(world=world)
     auto_game.place_initial_settlement(1, 1)
+    auto_game.faction_manager.toggle_assignment(
+        auto_game.player_faction, False, "mid"
+    )
 
     manual_before = manual_game.player_faction.resources[ResourceType.WOOD]
     auto_before = auto_game.player_faction.resources[ResourceType.WOOD]
 
-    for _ in range(3):
+    for _ in range(5):
         manual_game.tick()
         auto_game.tick()
 

--- a/world/world.py
+++ b/world/world.py
@@ -231,6 +231,8 @@ class World:
         for c in coords:
             d = downhill[c]
             if d:
+                if d not in flow:
+                    flow[d] = 0
                 flow[d] += flow[c]
 
         for c, f in flow.items():


### PR DESCRIPTION
## Summary
- allow toggling automated worker assignment per faction
- fix river generation for infinite worlds
- expand manual assignment resource test to use new toggle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842056d3680832bbe66178ee0dfd2f9