### PR TITLE
Implement per-tick resource output for offline gains

### DIFF
--- a/game/persistence.py
+++ b/game/persistence.py
@@ -446,10 +446,10 @@ def apply_offline_gains(
             for fac in factions:
                 fac.progress_projects()
 
-        # Compute the “steady-state” per-tick gains for each faction
+        # Compute the per-tick resource gains for each faction without
+        # modifying their stored values.
         per_tick_production: Dict[str, Dict[ResourceType, int]] = {}
         for fac in factions:
-            # Assume ResourceManager has a method .get_per_tick_output(fac)
             gains: Dict[ResourceType, int] = res_mgr.get_per_tick_output(fac)
             per_tick_production[fac.name] = gains
 


### PR DESCRIPTION
## Summary
- add `ResourceManager.get_per_tick_output` to compute resource gathering without changing state
- use the new helper in `apply_offline_gains`
- test batched offline gains through the new method

## Testing
- `pytest -q` *(fails: ImportError while importing world.world)*

------
https://chatgpt.com/codex/tasks/task_e_684258208714832ba3b1dd5e80fcd337