### PR TITLE
Add save-file CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ python main.py
 ```
 
 This loads `save.json` if it exists, applying any resource gains that would have
-accumulated while the game was not running.
+accumulated while the game was not running. Pass `--save-file <path>` to write
+the session's progress to a custom location.
 
 ## Worker Assignment Efficiency
 
@@ -103,9 +104,10 @@ workers each tick. Automated assignment gathers resources at reduced efficiency
 
 ## Saving Progress
 
-Call `game.save()` from your own scripts to persist the current state to
-`save.json`. The next time you run the game, `load_state()` will apply offline
-progress based on the timestamp stored in this file.
+Call `game.save()` from your own scripts to persist the current state. Pass a
+file path to `game.save(path)` if you want to use a custom save file rather than
+the default `save.json`. The next time you run the game, `load_state(path)` will
+apply offline progress based on the timestamp stored in that file.
 
 ## Recommended World Sizes
 

--- a/tests/test_custom_save_file.py
+++ b/tests/test_custom_save_file.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from game.game import Game
+from world.world import World, ResourceType
+import game.persistence as persistence
+from game import settings
+
+def test_save_to_custom_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "AI_FACTION_COUNT", 0)
+    world = World(width=3, height=3)
+    game = Game(world=world)
+    game.place_initial_settlement(1, 1)
+
+    # Modify resources so we can verify persistence
+    faction = game.player_faction
+    faction.resources[ResourceType.FOOD] = 5
+    game.resources.data[faction.name][ResourceType.FOOD] = 5
+
+    custom_path = tmp_path / "mysave.json"
+
+    monkeypatch.setattr(persistence.time, "time", lambda: 1000.0)
+    game.save(save_file=custom_path)
+
+    assert custom_path.exists()
+
+    monkeypatch.setattr(persistence.time, "time", lambda: 1000.0)
+    loaded_state, _ = persistence.load_state(save_file=custom_path)
+
+    assert loaded_state.resources[faction.name][ResourceType.FOOD] == 5
+
+

--- a/world/__init__.py
+++ b/world/__init__.py
@@ -11,6 +11,7 @@ from .generation import (
     compute_temperature,
     determine_biome,
     terrain_from_elevation,
+    perlin_noise,
 )
 from .hex import Hex
 from .resource_types import ResourceType, STRATEGIC_RESOURCES, LUXURY_RESOURCES
@@ -20,8 +21,9 @@ from .world import (
     Road,
     RiverSegment,
     World,
-    adjust_settings,
 )
+
+adjust_settings = World.adjust_settings
 
 __all__ = [
     "BIOME_COLORS",
@@ -39,6 +41,7 @@ __all__ = [
     "add_mythic_biomes",
     "adjust_settings",
     "apply_fantasy_overlays",
+    "perlin_noise",
     "compute_temperature",
     "determine_biome",
     "export_resources_json",

--- a/world/world.py
+++ b/world/world.py
@@ -45,6 +45,7 @@ from .resources import generate_resources
 from .hex import Hex, Coordinate
 from .settings import WorldSettings
 from .fantasy import apply_fantasy_overlays
+from .generation import perlin_noise as _perlin_noise, determine_biome as _determine_biome
 
 # ─────────────────────────────────────────────────────────────────────────────
 # == TYPE ALIASES & CUSTOM EXCEPTIONS ==
@@ -546,6 +547,7 @@ class World:
         "god_powers",
         "_known_width",
         "_known_height",
+        "_dirty_rivers",
     )
 
     def __init__(
@@ -1534,6 +1536,15 @@ class World:
         )
 
 
+# Convenience wrappers so other modules can import from world.world
+def perlin_noise(*args: Any, **kwargs: Any) -> float:
+    return _perlin_noise(*args, **kwargs)
+
+
+def determine_biome(*args: Any, **kwargs: Any) -> str:
+    return _determine_biome(*args, **kwargs)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # == PUBLIC API EXPOSURES ==
 
@@ -1550,5 +1561,7 @@ __all__ = [
     "register_biome_color",
     "register_biome_rule",
     "InvalidCoordinateError",
+    "perlin_noise",
+    "determine_biome",
     "World.adjust_settings",
 ]


### PR DESCRIPTION
## Summary
- expose `--save-file` option to CLI
- allow `save_state` and `load_state` to work with custom paths
- document new behaviour in README
- add regression test showing save to custom location
- fix world package imports and add convenience wrappers

## Testing
- `pytest tests/test_custom_save_file.py::test_save_to_custom_file -q`
- `pytest -q` *(fails: terrain must be a TerrainType)*

------
https://chatgpt.com/codex/tasks/task_e_6842582181bc832b80c98ab6a34d21f4