### PR TITLE
Add graceful shutdown to main demo

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,28 @@
 import time
+import argparse
 from world.world import World
 from ui.map_view import MapView, worker_assignment_dialog
 from ui.defense_building_ui import choose_defenses
+from typing import Optional
 from game.game import Game
 from game.buildings import Building
 
-def main():
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the interactive Globe-Trotter demo."
+    )
+    parser.add_argument(
+        "--no-save",
+        action="store_true",
+        help="Exit without saving the game state",
+    )
+    args = parser.parse_args()
+
     # Let the player choose a settlement via the map UI
     world = World(width=20, height=20)
     view = MapView(world)
     settlement = view.run()
+    game: Optional[Game] = None
 
     if settlement:
         q, r = settlement
@@ -30,20 +43,28 @@ def main():
         return
 
     # Main loop: advance game state every second
-    while True:
-        if game.player_faction and game.player_faction.manual_assignment:
-            workers = worker_assignment_dialog(game.player_faction)
-            assigned = game.player_faction.workers.assigned
-            if workers > assigned:
-                game.faction_manager.assign_workers(
-                    game.player_faction, workers - assigned
-                )
-            elif workers < assigned:
-                game.faction_manager.unassign_workers(
-                    game.player_faction, assigned - workers
-                )
-        game.tick()
-        time.sleep(1)
+    try:
+        while True:
+            if game.player_faction and game.player_faction.manual_assignment:
+                workers = worker_assignment_dialog(game.player_faction)
+                assigned = game.player_faction.workers.assigned
+                if workers > assigned:
+                    game.faction_manager.assign_workers(
+                        game.player_faction, workers - assigned
+                    )
+                elif workers < assigned:
+                    game.faction_manager.unassign_workers(
+                        game.player_faction, assigned - workers
+                    )
+            game.tick()
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nStopping game...")
+    finally:
+        if game is not None and not args.no_save:
+            game.save()
+        elif args.no_save:
+            print("Skipping save (--no-save)")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- handle `KeyboardInterrupt` while running the demo
- add `--no-save` flag to skip saving on exit
- save game state when quitting the loop

## Testing
- `pytest -q` *(fails: ImportError in world/world.py)*

------
https://chatgpt.com/codex/tasks/task_e_684258227f14832bb4b841c0c2816063