### PR TITLE
Add file path support for persistence

### DIFF
--- a/world/__init__.py
+++ b/world/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .export import export_resources_json, export_resources_xml
 from .fantasy import (
     add_crystal_forests,
@@ -20,8 +22,12 @@ from .world import (
     Road,
     RiverSegment,
     World,
-    adjust_settings,
 )
+
+# ``adjust_settings`` is provided for backward compatibility as a module-level
+# helper that forwards to ``World.adjust_settings``.
+def adjust_settings(settings: WorldSettings, world: "World" | None = None, **kwargs):
+    return World.adjust_settings(settings, world, **kwargs)
 
 __all__ = [
     "BIOME_COLORS",


### PR DESCRIPTION
## Summary
- extend `load_state` and `save_state` so callers may choose file locations
- allow `Game.save` to accept a path
- add `--save-file` CLI option and wire up both load/save paths
- expose `adjust_settings` helper in `world.__init__`
- tests for new parameters

## Testing
- `pytest tests/test_persistence.py::test_save_and_load_with_explicit_path -q` *(fails: ImportError and attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_68425824ead0832bad9c9cbfe061c88a